### PR TITLE
Add new MCP tools for views, fields, and users

### DIFF
--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -160,7 +160,7 @@ async def handle_list_tools() -> list[types.Tool]:
         ),
         types.Tool(
             name="get_tickets",
-            description="Fetch the latest tickets with pagination support",
+            description="Fetch the latest tickets with pagination support. Optionally filter by a specific view or status.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -183,6 +183,14 @@ async def handle_list_tools() -> list[types.Tool]:
                         "type": "string",
                         "description": "Sort order (asc or desc)",
                         "default": "desc"
+                    },
+                    "view_id": {
+                        "type": "integer",
+                        "description": "Optional view ID to filter tickets by a specific view"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Optional status filter (new, open, pending, hold, solved, closed)"
                     }
                 },
                 "required": []
@@ -244,6 +252,77 @@ async def handle_list_tools() -> list[types.Tool]:
                 },
                 "required": ["ticket_id"]
             }
+        ),
+        types.Tool(
+            name="list_views",
+            description="List all Zendesk views with pagination support",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    "per_page": {
+                        "type": "integer",
+                        "description": "Number of views per page (max 100)",
+                        "default": 25
+                    }
+                },
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="list_users",
+            description="List Zendesk users with optional role filter. Use role='agent' or role='admin' to list team members.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "description": "Filter by role: agent, admin, or end-user"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    "per_page": {
+                        "type": "integer",
+                        "description": "Number of users per page (max 100)",
+                        "default": 25
+                    }
+                },
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="list_ticket_fields",
+            description="List all ticket fields (system and custom) with their options",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="list_user_fields",
+            description="List all custom user fields with their options",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="list_organization_fields",
+            description="List all custom organization fields with their options",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
         )
     ]
 
@@ -287,12 +366,16 @@ async def handle_call_tool(
             per_page = arguments.get("per_page", 25) if arguments else 25
             sort_by = arguments.get("sort_by", "created_at") if arguments else "created_at"
             sort_order = arguments.get("sort_order", "desc") if arguments else "desc"
+            view_id = arguments.get("view_id") if arguments else None
+            status = arguments.get("status") if arguments else None
 
             tickets = zendesk_client.get_tickets(
                 page=page,
                 per_page=per_page,
                 sort_by=sort_by,
-                sort_order=sort_order
+                sort_order=sort_order,
+                view_id=view_id,
+                status=status
             )
             return [types.TextContent(
                 type="text",
@@ -334,6 +417,48 @@ async def handle_call_tool(
             return [types.TextContent(
                 type="text",
                 text=json.dumps({"message": "Ticket updated successfully", "ticket": updated}, indent=2)
+            )]
+
+        elif name == "list_views":
+            page = arguments.get("page", 1) if arguments else 1
+            per_page = arguments.get("per_page", 25) if arguments else 25
+
+            views = zendesk_client.get_views(page=page, per_page=per_page)
+            return [types.TextContent(
+                type="text",
+                text=json.dumps(views, indent=2)
+            )]
+
+        elif name == "list_users":
+            role = arguments.get("role") if arguments else None
+            page = arguments.get("page", 1) if arguments else 1
+            per_page = arguments.get("per_page", 25) if arguments else 25
+
+            users = zendesk_client.get_users(role=role, page=page, per_page=per_page)
+            return [types.TextContent(
+                type="text",
+                text=json.dumps(users, indent=2)
+            )]
+
+        elif name == "list_ticket_fields":
+            fields = zendesk_client.get_ticket_fields()
+            return [types.TextContent(
+                type="text",
+                text=json.dumps(fields, indent=2)
+            )]
+
+        elif name == "list_user_fields":
+            fields = zendesk_client.get_user_fields()
+            return [types.TextContent(
+                type="text",
+                text=json.dumps(fields, indent=2)
+            )]
+
+        elif name == "list_organization_fields":
+            fields = zendesk_client.get_organization_fields()
+            return [types.TextContent(
+                type="text",
+                text=json.dumps(fields, indent=2)
             )]
 
         else:

--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -83,7 +83,71 @@ class ZendeskClient:
         except Exception as e:
             raise Exception(f"Failed to post comment on ticket {ticket_id}: {str(e)}")
 
-    def get_tickets(self, page: int = 1, per_page: int = 25, sort_by: str = 'created_at', sort_order: str = 'desc') -> Dict[str, Any]:
+    def _search_tickets_by_status(self, status: str, page: int = 1, per_page: int = 25, sort_by: str = 'created_at', sort_order: str = 'desc') -> Dict[str, Any]:
+        """
+        Search tickets by status using the Zendesk Search API.
+
+        Args:
+            status: Status to filter by (new, open, pending, hold, solved, closed)
+            page: Page number (1-based)
+            per_page: Number of tickets per page (max 100)
+            sort_by: Field to sort by
+            sort_order: Sort order (asc or desc)
+
+        Returns:
+            Dict containing tickets and pagination info
+        """
+        # Build search query
+        query = f"type:ticket status:{status}"
+
+        params = {
+            'query': query,
+            'page': str(page),
+            'per_page': str(per_page),
+            'sort_by': sort_by,
+            'sort_order': sort_order
+        }
+        query_string = urllib.parse.urlencode(params)
+        url = f"{self.base_url}/search.json?{query_string}"
+
+        req = urllib.request.Request(url)
+        req.add_header('Authorization', self.auth_header)
+        req.add_header('Content-Type', 'application/json')
+
+        with urllib.request.urlopen(req) as response:
+            data = json.loads(response.read().decode())
+
+        results = data.get('results', [])
+
+        ticket_list = []
+        for ticket in results:
+            ticket_list.append({
+                'id': ticket.get('id'),
+                'subject': ticket.get('subject'),
+                'status': ticket.get('status'),
+                'priority': ticket.get('priority'),
+                'description': ticket.get('description'),
+                'created_at': ticket.get('created_at'),
+                'updated_at': ticket.get('updated_at'),
+                'requester_id': ticket.get('requester_id'),
+                'assignee_id': ticket.get('assignee_id')
+            })
+
+        return {
+            'tickets': ticket_list,
+            'page': page,
+            'per_page': per_page,
+            'count': len(ticket_list),
+            'total_count': data.get('count', len(ticket_list)),
+            'status_filter': status,
+            'sort_by': sort_by,
+            'sort_order': sort_order,
+            'has_more': data.get('next_page') is not None,
+            'next_page': page + 1 if data.get('next_page') else None,
+            'previous_page': page - 1 if data.get('previous_page') and page > 1 else None
+        }
+
+    def get_tickets(self, page: int = 1, per_page: int = 25, sort_by: str = 'created_at', sort_order: str = 'desc', view_id: int | None = None, status: str | None = None) -> Dict[str, Any]:
         """
         Get the latest tickets with proper pagination support using direct API calls.
 
@@ -92,6 +156,8 @@ class ZendeskClient:
             per_page: Number of tickets per page (max 100)
             sort_by: Field to sort by (created_at, updated_at, priority, status)
             sort_order: Sort order (asc or desc)
+            view_id: Optional view ID to filter tickets by a specific view
+            status: Optional status filter (new, open, pending, hold, solved, closed)
 
         Returns:
             Dict containing tickets and pagination info
@@ -99,6 +165,16 @@ class ZendeskClient:
         try:
             # Cap at reasonable limit
             per_page = min(per_page, 100)
+
+            # Use Search API if status filter is provided (and no view_id)
+            if status and not view_id:
+                return self._search_tickets_by_status(
+                    status=status,
+                    page=page,
+                    per_page=per_page,
+                    sort_by=sort_by,
+                    sort_order=sort_order
+                )
 
             # Build URL with parameters for offset pagination
             params = {
@@ -108,7 +184,11 @@ class ZendeskClient:
                 'sort_order': sort_order
             }
             query_string = urllib.parse.urlencode(params)
-            url = f"{self.base_url}/tickets.json?{query_string}"
+
+            if view_id:
+                url = f"{self.base_url}/views/{view_id}/tickets.json?{query_string}"
+            else:
+                url = f"{self.base_url}/tickets.json?{query_string}"
 
             # Create request with auth header
             req = urllib.request.Request(url)
@@ -243,6 +323,249 @@ class ZendeskClient:
             }
         except Exception as e:
             raise Exception(f"Failed to create ticket: {str(e)}")
+
+    def get_views(self, page: int = 1, per_page: int = 25) -> Dict[str, Any]:
+        """
+        Get the list of views with pagination support using direct API calls.
+
+        Args:
+            page: Page number (1-based)
+            per_page: Number of views per page (max 100)
+
+        Returns:
+            Dict containing views and pagination info
+        """
+        try:
+            per_page = min(per_page, 100)
+
+            params = {
+                'page': str(page),
+                'per_page': str(per_page)
+            }
+            query_string = urllib.parse.urlencode(params)
+            url = f"{self.base_url}/views.json?{query_string}"
+
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+
+            views_data = data.get('views', [])
+
+            view_list = []
+            for view in views_data:
+                view_list.append({
+                    'id': view.get('id'),
+                    'title': view.get('title'),
+                    'active': view.get('active'),
+                    'position': view.get('position'),
+                    'restriction': view.get('restriction'),
+                    'created_at': view.get('created_at'),
+                    'updated_at': view.get('updated_at'),
+                })
+
+            return {
+                'views': view_list,
+                'page': page,
+                'per_page': per_page,
+                'count': len(view_list),
+                'has_more': data.get('next_page') is not None,
+                'next_page': page + 1 if data.get('next_page') else None,
+                'previous_page': page - 1 if data.get('previous_page') and page > 1 else None
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get views: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get views: {str(e)}")
+
+    def get_users(self, role: str | None = None, page: int = 1, per_page: int = 25) -> Dict[str, Any]:
+        """
+        Get users with optional role filter and pagination.
+
+        Args:
+            role: Optional role filter (agent, admin, end-user)
+            page: Page number (1-based)
+            per_page: Number of users per page (max 100)
+
+        Returns:
+            Dict containing users and pagination info
+        """
+        try:
+            per_page = min(per_page, 100)
+
+            params = {
+                'page': str(page),
+                'per_page': str(per_page)
+            }
+            if role:
+                params['role'] = role
+
+            query_string = urllib.parse.urlencode(params)
+            url = f"{self.base_url}/users.json?{query_string}"
+
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+
+            users_data = data.get('users', [])
+
+            user_list = []
+            for user in users_data:
+                user_list.append({
+                    'id': user.get('id'),
+                    'name': user.get('name'),
+                    'email': user.get('email'),
+                    'role': user.get('role'),
+                    'active': user.get('active'),
+                    'created_at': user.get('created_at'),
+                    'updated_at': user.get('updated_at'),
+                })
+
+            return {
+                'users': user_list,
+                'page': page,
+                'per_page': per_page,
+                'count': len(user_list),
+                'role_filter': role,
+                'has_more': data.get('next_page') is not None,
+                'next_page': page + 1 if data.get('next_page') else None,
+                'previous_page': page - 1 if data.get('previous_page') and page > 1 else None
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get users: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get users: {str(e)}")
+
+    def get_ticket_fields(self) -> Dict[str, Any]:
+        """
+        Get all ticket fields (system and custom) with their options.
+
+        Returns:
+            Dict containing ticket fields and their options
+        """
+        try:
+            url = f"{self.base_url}/ticket_fields.json"
+
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+
+            fields_data = data.get('ticket_fields', [])
+
+            field_list = []
+            for field in fields_data:
+                field_list.append({
+                    'id': field.get('id'),
+                    'type': field.get('type'),
+                    'title': field.get('title'),
+                    'description': field.get('description'),
+                    'active': field.get('active'),
+                    'required': field.get('required'),
+                    'custom_field_options': field.get('custom_field_options'),
+                    'system_field_options': field.get('system_field_options'),
+                })
+
+            return {
+                'ticket_fields': field_list,
+                'count': len(field_list)
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get ticket fields: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get ticket fields: {str(e)}")
+
+    def get_user_fields(self) -> Dict[str, Any]:
+        """
+        Get all custom user fields with their options.
+
+        Returns:
+            Dict containing user fields and their options
+        """
+        try:
+            url = f"{self.base_url}/user_fields.json"
+
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+
+            fields_data = data.get('user_fields', [])
+
+            field_list = []
+            for field in fields_data:
+                field_list.append({
+                    'id': field.get('id'),
+                    'key': field.get('key'),
+                    'type': field.get('type'),
+                    'title': field.get('title'),
+                    'description': field.get('description'),
+                    'active': field.get('active'),
+                    'custom_field_options': field.get('custom_field_options'),
+                })
+
+            return {
+                'user_fields': field_list,
+                'count': len(field_list)
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get user fields: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get user fields: {str(e)}")
+
+    def get_organization_fields(self) -> Dict[str, Any]:
+        """
+        Get all custom organization fields with their options.
+
+        Returns:
+            Dict containing organization fields and their options
+        """
+        try:
+            url = f"{self.base_url}/organization_fields.json"
+
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+
+            fields_data = data.get('organization_fields', [])
+
+            field_list = []
+            for field in fields_data:
+                field_list.append({
+                    'id': field.get('id'),
+                    'key': field.get('key'),
+                    'type': field.get('type'),
+                    'title': field.get('title'),
+                    'description': field.get('description'),
+                    'active': field.get('active'),
+                    'custom_field_options': field.get('custom_field_options'),
+                })
+
+            return {
+                'organization_fields': field_list,
+                'count': len(field_list)
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get organization fields: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get organization fields: {str(e)}")
 
     def update_ticket(self, ticket_id: int, **fields: Any) -> Dict[str, Any]:
         """


### PR DESCRIPTION
- Add list_views tool to retrieve Zendesk views with pagination
- Add view_id parameter to get_tickets for filtering by view
- Add status parameter to get_tickets for filtering by ticket status
- Add list_ticket_fields tool to retrieve ticket custom fields and options
- Add list_user_fields tool to retrieve user custom fields
- Add list_organization_fields tool to retrieve organization custom fields
- Add list_users tool to list users with optional role filter (agent/admin/end-user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)