### PR TITLE
Validate attachment hosts before fetching content_url

### DIFF
--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -31,6 +31,14 @@ class ZendeskClient:
         encoded_credentials = base64.b64encode(credentials.encode()).decode('ascii')
         self.auth_header = f"Basic {encoded_credentials}"
 
+        # Only Zendesk-controlled attachment hosts may be fetched.
+        self._trusted_attachment_hosts = {
+            f"{subdomain}.zendesk.com",
+        }
+        self._trusted_attachment_host_suffixes = (
+            ".zdusercontent.com",
+        )
+
     def get_ticket(self, ticket_id: int) -> Dict[str, Any]:
         """
         Query a ticket by its ID
@@ -110,9 +118,31 @@ class ZendeskClient:
         which is required — the CDN returns 403 if it receives an auth header.
         """
         try:
+            parsed_url = urllib.parse.urlparse(content_url)
+            if parsed_url.scheme.lower() != 'https':
+                raise ValueError("Attachment URL must use HTTPS.")
+
+            hostname = (parsed_url.hostname or '').lower()
+            if not hostname:
+                raise ValueError("Attachment URL must include a valid hostname.")
+
+            is_trusted_host = (
+                hostname in self._trusted_attachment_hosts
+                or any(hostname.endswith(suffix) for suffix in self._trusted_attachment_host_suffixes)
+            )
+            if not is_trusted_host:
+                raise ValueError(
+                    "Attachment host is not trusted. Only Zendesk-hosted attachment URLs are allowed."
+                )
+
+            # Only send Zendesk credentials to the account subdomain. CDN hosts don't need them.
+            headers = {}
+            if hostname == f"{self.subdomain}.zendesk.com":
+                headers['Authorization'] = self.auth_header
+
             response = _requests.get(
                 content_url,
-                headers={'Authorization': self.auth_header},
+                headers=headers,
                 timeout=30,
                 stream=True,
             )


### PR DESCRIPTION
## Summary

Fix `get_ticket_attachment()` leaking Zendesk credentials to arbitrary hosts supplied via `content_url`.

## Problem

`get_ticket_attachment()` currently accepts any URL and immediately requests it with the Zendesk `Authorization` header attached.

That means the destination host is controlled by the caller, not by server configuration:

- the Zendesk credentials come from environment variables (`ZENDESK_SUBDOMAIN`, `ZENDESK_EMAIL`, `ZENDESK_API_KEY`)
- the request destination comes from the `content_url` argument passed to the MCP tool

So if a caller provides `https://attacker.example/steal.png`, the server will send:

```http
Authorization: Basic <base64(email/token:api_token)>
```

to `attacker.example` before any validation.

This is a credential disclosure issue, not just a bad attachment fetch.

## Patch

This change adds host validation before making the request:

- require `https`
- allow only Zendesk-controlled attachment hosts
- send the Zendesk `Authorization` header only to `<subdomain>.zendesk.com`
- allow `*.zdusercontent.com` without forwarding credentials

This keeps the existing Zendesk attachment flow working:

- account attachment URLs on `<subdomain>.zendesk.com` still receive auth
- redirects to Zendesk's CDN still work
- arbitrary third-party hosts are rejected before any credential-bearing request is made

## Why This Fix

Zendesk attachment/comment URLs may be externally hosted, so the client must not treat `content_url` as trusted input.

The important security boundary is:

- validate the destination host first
- only then decide whether credentials should be attached
