### PR TITLE
feat: add 17 new API tools (search, users, views, fields, orgs, groups, macros, forms)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 ZENDESK_SUBDOMAIN=xxx
+# Token auth (recommended): set email + API key
 ZENDESK_EMAIL=xxx
 ZENDESK_API_KEY=xxx
+# Cookie auth (alternative): set session cookie from browser
+# ZENDESK_SESSION_COOKIE=xxx

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 ZENDESK_SUBDOMAIN=xxx
-# Token auth (recommended): set email + API key
-ZENDESK_EMAIL=xxx
-ZENDESK_API_KEY=xxx
-# Cookie auth (alternative): set session cookie from browser
+
+# Option 1: OAuth (recommended) - run 'zendesk-auth' to authenticate
+# The token is saved to .zendesk_token automatically.
+# Or set it manually:
+# ZENDESK_OAUTH_TOKEN=xxx
+
+# Option 2: API token auth - set email + API key
+# ZENDESK_EMAIL=xxx
+# ZENDESK_API_KEY=xxx
+
+# Option 3: Cookie auth - set session cookie from browser
 # ZENDESK_SESSION_COOKIE=xxx

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ wheels/
 .env
 .env.prod
 .env.dev
+.zendesk_token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,4 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 zendesk = "zendesk_mcp_server:main"
+zendesk-auth = "zendesk_mcp_server.auth:main"

--- a/src/zendesk_mcp_server/auth.py
+++ b/src/zendesk_mcp_server/auth.py
@@ -13,8 +13,11 @@ import json
 import logging
 import os
 import platform
+import shutil
 import socket
+import subprocess
 import sys
+import tempfile
 import threading
 import uuid
 import webbrowser
@@ -244,12 +247,204 @@ def _build_auth_url(auth_url: str) -> str:
     return f"{auth_url}?{urlencode({'client_id': CLIENT_ID, 'device[name]': device_name, 'device[identifier]': device_id})}"
 
 
+class _UrlSchemeHandler:
+    """
+    Registers a temporary OS-level URL scheme handler for zendesk-support://.
+
+    When the browser follows the OAuth redirect to zendesk-support://...,
+    the OS routes it to our handler, which forwards the URL to our local
+    HTTP server. Fully automatic — no manual copy/paste.
+
+    Supports macOS, Linux (via xdg-mime), and Windows (via registry).
+    """
+
+    SCHEME = "zendesk-support"
+
+    def __init__(self, callback_port: int):
+        self.callback_port = callback_port
+        self._cleanup_actions: list = []
+
+    def register(self) -> bool:
+        """Create and register the handler. Returns True on success."""
+        try:
+            if sys.platform == "darwin":
+                return self._register_macos()
+            elif sys.platform == "linux":
+                return self._register_linux()
+            elif sys.platform == "win32":
+                return self._register_windows()
+            return False
+        except Exception as e:
+            logger.warning(f"Could not register URL scheme handler: {e}")
+            self.cleanup()
+            return False
+
+    def cleanup(self):
+        """Undo all registrations and remove temp files."""
+        for action in reversed(self._cleanup_actions):
+            try:
+                action()
+            except Exception:
+                pass
+        self._cleanup_actions.clear()
+
+    # --- macOS ---
+
+    def _register_macos(self) -> bool:
+        import plistlib
+        lsregister = (
+            "/System/Library/Frameworks/CoreServices.framework"
+            "/Frameworks/LaunchServices.framework/Support/lsregister"
+        )
+        # Must be in ~/Applications for Launch Services to find it
+        apps_dir = os.path.expanduser("~/Applications")
+        os.makedirs(apps_dir, exist_ok=True)
+        app_dir = os.path.join(apps_dir, "ZendeskMCPAuth.app")
+
+        # Clean up any previous handler first
+        shutil.rmtree(app_dir, ignore_errors=True)
+
+        # Compile an AppleScript that handles the URL scheme via Apple Events.
+        # `on open location` is how macOS delivers custom-scheme URLs to apps.
+        # Write to temp file to avoid shell escaping issues with -e flag.
+        script_file = os.path.join(tempfile.gettempdir(), "zendesk_auth.applescript")
+        with open(script_file, "w") as f:
+            f.write(
+                'on open location theURL\n'
+                '    do shell script "/usr/bin/curl -s -G '
+                '--data-urlencode url=" & quoted form of theURL '
+                f'& " \'http://127.0.0.1:{self.callback_port}/callback\''
+                ' > /dev/null 2>&1 &"\n'
+                'end open location\n'
+            )
+        try:
+            subprocess.run(
+                ["osacompile", "-o", app_dir, script_file],
+                check=True, capture_output=True,
+            )
+        finally:
+            os.unlink(script_file)
+
+        # Patch Info.plist to register the URL scheme
+        plist_path = os.path.join(app_dir, "Contents", "Info.plist")
+        with open(plist_path, "rb") as f:
+            info_plist = plistlib.load(f)
+
+        info_plist["CFBundleIdentifier"] = "com.zendesk-mcp-server.auth"
+        info_plist["CFBundleURLTypes"] = [
+            {
+                "CFBundleURLName": "Zendesk Support OAuth",
+                "CFBundleURLSchemes": [self.SCHEME],
+            }
+        ]
+        with open(plist_path, "wb") as f:
+            plistlib.dump(info_plist, f)
+
+        # Register with Launch Services (-f to force)
+        subprocess.run([lsregister, "-f", app_dir], check=True, capture_output=True)
+
+        def _cleanup():
+            subprocess.run([lsregister, "-u", app_dir], capture_output=True)
+            shutil.rmtree(app_dir, ignore_errors=True)
+
+        self._cleanup_actions.append(_cleanup)
+        logger.info(f"Registered macOS URL scheme handler: {app_dir}")
+        return True
+
+    # --- Linux ---
+
+    def _register_linux(self) -> bool:
+        apps_dir = os.path.expanduser("~/.local/share/applications")
+        os.makedirs(apps_dir, exist_ok=True)
+
+        # Create a helper script that curls our local server
+        script_path = os.path.join(tempfile.gettempdir(), "zendesk-mcp-auth-handler.sh")
+        with open(script_path, "w") as f:
+            f.write(f"""#!/bin/sh
+curl -s -G --data-urlencode "url=$1" \\
+    "http://127.0.0.1:{self.callback_port}/callback" \\
+    >/dev/null 2>&1 &
+""")
+        os.chmod(script_path, 0o755)
+
+        # Create .desktop file
+        desktop_path = os.path.join(apps_dir, "zendesk-mcp-auth.desktop")
+        with open(desktop_path, "w") as f:
+            f.write(f"""[Desktop Entry]
+Type=Application
+Name=Zendesk MCP Auth
+Exec={script_path} %u
+NoDisplay=true
+MimeType=x-scheme-handler/{self.SCHEME};
+""")
+
+        # Register as default handler
+        subprocess.run(
+            ["xdg-mime", "default", "zendesk-mcp-auth.desktop",
+             f"x-scheme-handler/{self.SCHEME}"],
+            check=True, capture_output=True,
+        )
+
+        def _cleanup():
+            os.unlink(desktop_path)
+            os.unlink(script_path)
+            # xdg-mime doesn't have an "unregister", removing the file is enough
+
+        self._cleanup_actions.append(_cleanup)
+        logger.info("Registered Linux URL scheme handler via xdg-mime")
+        return True
+
+    # --- Windows ---
+
+    def _register_windows(self) -> bool:
+        import winreg
+
+        # Create a helper batch script
+        script_path = os.path.join(tempfile.gettempdir(), "zendesk-mcp-auth.bat")
+        with open(script_path, "w") as f:
+            f.write(f"""@echo off
+curl -s -G --data-urlencode "url=%1" ^
+    "http://127.0.0.1:{self.callback_port}/callback" >nul 2>&1
+""")
+
+        # Register URL protocol in HKCU (no admin needed)
+        key_path = f"Software\\Classes\\{self.SCHEME}"
+        winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path)
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_WRITE) as key:
+            winreg.SetValueEx(key, "", 0, winreg.REG_SZ, f"URL:{self.SCHEME}")
+            winreg.SetValueEx(key, "URL Protocol", 0, winreg.REG_SZ, "")
+
+        cmd_path = f"{key_path}\\shell\\open\\command"
+        winreg.CreateKey(winreg.HKEY_CURRENT_USER, cmd_path)
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, cmd_path, 0, winreg.KEY_WRITE) as key:
+            winreg.SetValueEx(key, "", 0, winreg.REG_SZ, f'"{script_path}" "%1"')
+
+        def _cleanup():
+            try:
+                # Delete in reverse order (leaf keys first)
+                for sub in [f"{key_path}\\shell\\open\\command",
+                            f"{key_path}\\shell\\open",
+                            f"{key_path}\\shell", key_path]:
+                    winreg.DeleteKey(winreg.HKEY_CURRENT_USER, sub)
+            except OSError:
+                pass
+            os.unlink(script_path)
+
+        self._cleanup_actions.append(_cleanup)
+        logger.info("Registered Windows URL scheme handler via registry")
+        return True
+
+
 def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
     """
     Non-interactive browser-based OAuth flow.
 
     Discovers auth methods for the subdomain, opens the system browser,
     and waits for the user to complete authentication. No stdin required.
+
+    On macOS, registers a temporary URL scheme handler so the
+    zendesk-support:// redirect is captured automatically.
+    On other platforms, falls back to a paste-the-URL page.
 
     Used by the MCP server on startup when no valid auth is present.
     """
@@ -267,9 +462,7 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
     login = agent_logins[0]
     service = login.get("service")
 
-    # For all methods, use the browser-based flow
     if service == "zendesk":
-        # Email/password: use the web OAuth URL
         auth_url = login.get("url", f"https://{subdomain}.zendesk.com/access/oauth_mobile")
     else:
         auth_url = login.get("zendesk_url") or login.get("url")
@@ -279,7 +472,7 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
 
     full_auth_url = _build_auth_url(auth_url)
 
-    # Start local HTTP server for the auth page
+    # Start local HTTP server to receive the callback
     port = _find_free_port()
     result = {}
 
@@ -293,13 +486,9 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
                 if token_data:
                     result.update(token_data)
                     self.send_response(200)
-                    self.send_header("Content-Type", "application/json")
-                    self.send_header("Access-Control-Allow-Origin", "*")
+                    self.send_header("Content-Type", "text/html")
                     self.end_headers()
-                    self.wfile.write(json.dumps({
-                        "ok": True,
-                        "username": token_data.get("username"),
-                    }).encode())
+                    self.wfile.write(SUCCESS_HTML.encode())
                     threading.Thread(target=self.server.shutdown, daemon=True).start()
                 else:
                     self.send_response(200)
@@ -310,6 +499,7 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
                         "error": "Could not parse access token from URL.",
                     }).encode())
             else:
+                # Fallback page for manual paste (when URL scheme handler isn't available)
                 html = AUTH_PAGE_HTML.format(auth_url=full_auth_url)
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html")
@@ -323,12 +513,26 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
 
-    local_url = f"http://127.0.0.1:{port}/auth"
-    logger.info(f"Opening browser for authentication: {local_url}")
-    webbrowser.open(local_url)
+    # Try to register a URL scheme handler (macOS only)
+    scheme_handler = _UrlSchemeHandler(port)
+    handler_registered = scheme_handler.register()
 
-    server_thread.join(timeout=timeout)
-    server.server_close()
+    try:
+        if handler_registered:
+            # Handler registered — open the auth URL directly.
+            # The OS will route zendesk-support:// back to our handler.
+            logger.info("URL scheme handler registered. Opening Zendesk login directly.")
+            webbrowser.open(full_auth_url)
+        else:
+            # No handler — open our local page with paste instructions
+            local_url = f"http://127.0.0.1:{port}/auth"
+            logger.info(f"Opening browser for authentication: {local_url}")
+            webbrowser.open(local_url)
+
+        server_thread.join(timeout=timeout)
+        server.server_close()
+    finally:
+        scheme_handler.cleanup()
 
     if not result:
         raise RuntimeError(

--- a/src/zendesk_mcp_server/auth.py
+++ b/src/zendesk_mcp_server/auth.py
@@ -1,7 +1,7 @@
 """
 OAuth authentication for Zendesk using the mobile app's OAuth flow.
 
-Supports two auth methods discovered via /api/mobile/account/lookup.json:
+Supports auth methods discovered via /api/mobile/account/lookup.json:
 - Email/password: direct POST to /access/oauth_mobile (no browser needed)
 - SSO (SAML/Google/Office365): opens system browser, user pastes callback URL
 
@@ -10,6 +10,7 @@ The access_token is saved to a token file for the MCP server to use.
 
 import getpass
 import json
+import logging
 import os
 import platform
 import socket
@@ -23,74 +24,115 @@ from urllib.parse import urlencode, urlparse, parse_qs
 
 import requests
 
+logger = logging.getLogger("zendesk-mcp-server")
+
 CLIENT_ID = "zendesk_support_android"
-OAUTH_SCHEME = "zendesk-support"
 USER_AGENT = "Zendesk-SDK/1.0 Android/30 Variant/Core"
 TOKEN_FILE = ".zendesk_token"
 
-# HTML served by the local callback server after capturing the token
 SUCCESS_HTML = """<!DOCTYPE html>
 <html><head><title>Zendesk Auth</title></head>
-<body style="font-family:sans-serif;text-align:center;padding:60px">
-<h2>Authentication successful!</h2>
-<p>You can close this tab and return to the terminal.</p>
+<body style="font-family:system-ui,sans-serif;text-align:center;padding:60px">
+<h2>&#9989; Authentication successful!</h2>
+<p>You can close this tab. The MCP server is starting.</p>
 </body></html>"""
 
-# HTML page that intercepts the custom scheme redirect
-INTERCEPT_HTML = """<!DOCTYPE html>
+AUTH_PAGE_HTML = """<!DOCTYPE html>
 <html><head><title>Zendesk Auth</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 520px; margin: 40px auto; padding: 20px; }}
+  h2 {{ color: #333; }}
+  .step {{ margin: 16px 0; padding: 12px; background: #f5f5f5; border-radius: 8px; }}
+  .step-num {{ font-weight: bold; color: #03363D; }}
+  input {{ width: 100%; padding: 10px; font-size: 14px; box-sizing: border-box;
+           border: 2px solid #ccc; border-radius: 6px; }}
+  input:focus {{ border-color: #03363D; outline: none; }}
+  button {{ padding: 12px 24px; font-size: 15px; cursor: pointer; border: none;
+            background: #03363D; color: white; border-radius: 6px; margin-top: 8px; }}
+  button:hover {{ background: #04494F; }}
+  #result {{ display: none; text-align: center; padding: 40px; }}
+  #result h2 {{ color: #2e7d32; }}
+  .spinner {{ display: inline-block; width: 20px; height: 20px; border: 3px solid #ccc;
+              border-top-color: #03363D; border-radius: 50%; animation: spin 0.8s linear infinite; }}
+  @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
+</style>
 <script>
-// Listen for navigation to the custom scheme by polling the page location
-// and by intercepting link clicks. The actual mechanism: after SSO completes,
-// Zendesk redirects to zendesk-support://...?access_token=...
-// The browser can't handle this scheme, so we catch it via a service worker
-// or by having the user paste the URL.
+var authWindow = null;
+var pollInterval = null;
 
-// On page load, show instructions
-document.addEventListener('DOMContentLoaded', function() {{
-    document.getElementById('status').textContent = 'Redirecting to Zendesk login...';
-    setTimeout(function() {{
-        window.location.href = '{auth_url}';
+function openAuth() {{
+    authWindow = window.open('{auth_url}', '_blank');
+    document.getElementById('step2').style.display = 'block';
+    // Poll for the popup navigating to the custom scheme (will fail with error)
+    pollInterval = setInterval(function() {{
+        if (authWindow && authWindow.closed) {{
+            clearInterval(pollInterval);
+        }}
     }}, 1000);
-    // After redirect, show paste instructions (the redirect to custom scheme will fail)
-    setTimeout(function() {{
-        document.getElementById('paste-section').style.display = 'block';
-        document.getElementById('status').textContent =
-            'If you see an error about "zendesk-support://" not being recognized, ' +
-            'copy the full URL from the address bar and paste it below.';
-    }}, 5000);
-}});
+}}
 
 function submitUrl() {{
     var url = document.getElementById('callback-url').value.trim();
-    if (url) {{
-        fetch('/callback?url=' + encodeURIComponent(url))
-            .then(function() {{
-                document.body.innerHTML = '<h2 style="text-align:center;padding:60px;font-family:sans-serif">' +
-                    'Authentication successful! You can close this tab.</h2>';
-            }});
-    }}
+    if (!url) return;
+    document.getElementById('steps').style.display = 'none';
+    document.getElementById('result').style.display = 'block';
+    fetch('/callback?url=' + encodeURIComponent(url))
+        .then(r => r.json())
+        .then(function(data) {{
+            if (data.ok) {{
+                document.getElementById('result').innerHTML =
+                    '<h2>&#9989; Authentication successful!</h2>' +
+                    '<p>Welcome, ' + (data.username || 'agent') + '! You can close this tab.</p>';
+            }} else {{
+                document.getElementById('result').innerHTML =
+                    '<h2 style="color:#c62828">&#10060; Authentication failed</h2>' +
+                    '<p>' + (data.error || 'Could not parse token from URL.') + '</p>' +
+                    '<p>Make sure you copied the full URL starting with zendesk-support://</p>';
+                document.getElementById('steps').style.display = 'block';
+                document.getElementById('result').style.display = 'none';
+            }}
+        }});
 }}
+
+// Allow Enter key in the input
+document.addEventListener('DOMContentLoaded', function() {{
+    document.getElementById('callback-url').addEventListener('keypress', function(e) {{
+        if (e.key === 'Enter') submitUrl();
+    }});
+}});
 </script>
 </head>
-<body style="font-family:sans-serif;max-width:600px;margin:40px auto;padding:20px">
+<body>
 <h2>Zendesk Authentication</h2>
-<p id="status">Initializing...</p>
-<div id="paste-section" style="display:none;margin-top:30px">
-    <p><strong>Paste the callback URL here:</strong></p>
-    <input type="text" id="callback-url" style="width:100%;padding:8px;font-size:14px"
-           placeholder="zendesk-support://?access_token=...">
-    <br><br>
-    <button onclick="submitUrl()" style="padding:10px 20px;font-size:14px;cursor:pointer">
-        Submit
-    </button>
+<div id="steps">
+  <div class="step">
+    <p><span class="step-num">Step 1:</span> Sign in to Zendesk</p>
+    <button onclick="openAuth()">Open Zendesk Login</button>
+  </div>
+  <div class="step" id="step2" style="display:none">
+    <p><span class="step-num">Step 2:</span> After signing in, the browser will show an error page
+    about <code>zendesk-support://</code> not being recognized.</p>
+    <p>Copy the <strong>full URL</strong> from the address bar and paste it here:</p>
+    <input type="text" id="callback-url" placeholder="zendesk-support://?access_token=...">
+    <br>
+    <button onclick="submitUrl()">Authenticate</button>
+  </div>
+</div>
+<div id="result">
+  <div class="spinner"></div>
+  <p>Verifying...</p>
 </div>
 </body></html>"""
 
 
+def _project_dir() -> str:
+    """Return the project root (where pyproject.toml lives)."""
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
 def get_token_path(project_dir: str = None) -> Path:
     """Get the path to the token file."""
-    base = Path(project_dir) if project_dir else Path.cwd()
+    base = Path(project_dir) if project_dir else Path(_project_dir())
     return base / TOKEN_FILE
 
 
@@ -116,6 +158,19 @@ def save_token(token_data: dict, project_dir: str = None) -> Path:
     return path
 
 
+def verify_token(subdomain: str, access_token: str) -> bool:
+    """Check if an existing token is still valid."""
+    try:
+        resp = requests.get(
+            f"https://{subdomain}.zendesk.com/api/v2/users/me.json",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
 def lookup_subdomain(subdomain: str) -> dict:
     """Call the mobile account lookup endpoint to discover auth methods."""
     url = f"https://{subdomain}.zendesk.com/api/mobile/account/lookup.json"
@@ -136,8 +191,7 @@ def auth_email_password(subdomain: str, email: str, password: str) -> dict:
         "nativeMobile": True,
     }
     resp = requests.post(
-        url,
-        json=payload,
+        url, json=payload,
         headers={"User-Agent": USER_AGENT, "Content-Type": "application/json"},
         timeout=30,
     )
@@ -160,99 +214,12 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-def auth_sso_browser(subdomain: str, auth_url: str) -> dict:
-    """
-    Authenticate via SSO using the system browser.
-
-    Opens a local HTTP server that:
-    1. Serves a page that redirects to the Zendesk SSO URL
-    2. After SSO, Zendesk redirects to zendesk-support://?access_token=...
-    3. The browser can't handle the custom scheme, so the user pastes the URL
-    4. The local server parses the token and shuts down
-    """
-    port = _find_free_port()
-    result = {}
-    server_ready = threading.Event()
-
-    device_id = str(uuid.uuid4())
-    device_name = platform.node() or "zendesk-mcp"
-    full_auth_url = f"{auth_url}?{urlencode({'client_id': CLIENT_ID, 'device[name]': device_name, 'device[identifier]': device_id})}"
-
-    class CallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            parsed = urlparse(self.path)
-            if parsed.path == "/callback":
-                params = parse_qs(parsed.query)
-                callback_url = params.get("url", [""])[0]
-                token_data = _parse_oauth_callback(callback_url, subdomain)
-                if token_data:
-                    result.update(token_data)
-                self.send_response(200)
-                self.send_header("Content-Type", "text/html")
-                self.end_headers()
-                self.wfile.write(SUCCESS_HTML.encode())
-                threading.Thread(target=self.server.shutdown, daemon=True).start()
-            else:
-                # Serve the intercept page
-                html = INTERCEPT_HTML.format(auth_url=full_auth_url)
-                self.send_response(200)
-                self.send_header("Content-Type", "text/html")
-                self.end_headers()
-                self.wfile.write(html.encode())
-
-        def log_message(self, format, *args):
-            pass  # Suppress HTTP logs
-
-    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
-    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    server_thread.start()
-
-    local_url = f"http://127.0.0.1:{port}/auth"
-    print(f"\nOpening browser for Zendesk SSO login...")
-    print(f"If the browser doesn't open, visit: {local_url}\n")
-    webbrowser.open(local_url)
-
-    print("Waiting for authentication...")
-    print("After signing in, if the browser shows an error about 'zendesk-support://',")
-    print("copy the full URL from the address bar and paste it into the browser page.\n")
-    print("Or paste it here and press Enter:")
-    print("(Press Ctrl+C to cancel)\n")
-
-    # Also accept paste from stdin as fallback
-    input_thread_result = {}
-
-    def read_stdin():
-        try:
-            line = input("> ").strip()
-            if line and not result:
-                token_data = _parse_oauth_callback(line, subdomain)
-                if token_data:
-                    input_thread_result.update(token_data)
-                    server.shutdown()
-        except (EOFError, KeyboardInterrupt):
-            server.shutdown()
-
-    stdin_thread = threading.Thread(target=read_stdin, daemon=True)
-    stdin_thread.start()
-
-    server_thread.join(timeout=300)  # 5 min timeout
-    server.server_close()
-
-    if result:
-        return result
-    if input_thread_result:
-        return input_thread_result
-    raise RuntimeError("Authentication timed out or was cancelled.")
-
-
 def _parse_oauth_callback(url: str, subdomain: str) -> dict | None:
     """Parse the OAuth callback URL to extract token data."""
     if not url:
         return None
-    # Handle both zendesk-support://...?params and zendesk-support://?params
     parsed = urlparse(url)
     params = parse_qs(parsed.query)
-    # Also try fragment (some OAuth flows put params in the fragment)
     if not params and parsed.fragment:
         params = parse_qs(parsed.fragment)
 
@@ -270,6 +237,214 @@ def _parse_oauth_callback(url: str, subdomain: str) -> dict | None:
     }
 
 
+def _build_auth_url(auth_url: str) -> str:
+    """Build the full auth URL with client_id and device params."""
+    device_id = str(uuid.uuid4())
+    device_name = platform.node() or "zendesk-mcp"
+    return f"{auth_url}?{urlencode({'client_id': CLIENT_ID, 'device[name]': device_name, 'device[identifier]': device_id})}"
+
+
+def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
+    """
+    Non-interactive browser-based OAuth flow.
+
+    Discovers auth methods for the subdomain, opens the system browser,
+    and waits for the user to complete authentication. No stdin required.
+
+    Used by the MCP server on startup when no valid auth is present.
+    """
+    logger.info(f"No valid auth found. Starting browser authentication for {subdomain}...")
+
+    lookup = lookup_subdomain(subdomain)
+    agent_logins = lookup.get("agent_logins", [])
+    if not agent_logins:
+        raise RuntimeError(f"No login methods available for {subdomain}.zendesk.com")
+
+    # Prefer SSO > Google > Office365 > email/password (browser flow for all)
+    priority = {"remote": 0, "google": 1, "office_365": 2, "zendesk": 3}
+    agent_logins.sort(key=lambda x: priority.get(x.get("service", ""), 99))
+
+    login = agent_logins[0]
+    service = login.get("service")
+
+    # For all methods, use the browser-based flow
+    if service == "zendesk":
+        # Email/password: use the web OAuth URL
+        auth_url = login.get("url", f"https://{subdomain}.zendesk.com/access/oauth_mobile")
+    else:
+        auth_url = login.get("zendesk_url") or login.get("url")
+
+    if not auth_url:
+        raise RuntimeError("No authentication URL found.")
+
+    full_auth_url = _build_auth_url(auth_url)
+
+    # Start local HTTP server for the auth page
+    port = _find_free_port()
+    result = {}
+
+    class AuthHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                params = parse_qs(parsed.query)
+                callback_url = params.get("url", [""])[0]
+                token_data = _parse_oauth_callback(callback_url, subdomain)
+                if token_data:
+                    result.update(token_data)
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Access-Control-Allow-Origin", "*")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({
+                        "ok": True,
+                        "username": token_data.get("username"),
+                    }).encode())
+                    threading.Thread(target=self.server.shutdown, daemon=True).start()
+                else:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({
+                        "ok": False,
+                        "error": "Could not parse access token from URL.",
+                    }).encode())
+            else:
+                html = AUTH_PAGE_HTML.format(auth_url=full_auth_url)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(html.encode())
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), AuthHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    local_url = f"http://127.0.0.1:{port}/auth"
+    logger.info(f"Opening browser for authentication: {local_url}")
+    webbrowser.open(local_url)
+
+    server_thread.join(timeout=timeout)
+    server.server_close()
+
+    if not result:
+        raise RuntimeError(
+            "Authentication timed out. Run 'zendesk-auth' manually to authenticate."
+        )
+
+    return result
+
+
+def ensure_auth(subdomain: str) -> dict | None:
+    """
+    Ensure valid authentication exists. Returns token data.
+
+    1. Check for existing token file
+    2. If valid, return it
+    3. If not, open browser for OAuth
+    4. Save and return the new token
+
+    Called by the MCP server on startup.
+    """
+    # Check existing token
+    token_data = load_token()
+    if token_data:
+        # Verify it's for the right subdomain
+        if token_data.get("subdomain") == subdomain:
+            if verify_token(subdomain, token_data["access_token"]):
+                logger.info("Existing OAuth token is valid")
+                return token_data
+            else:
+                logger.info("Existing OAuth token is expired or invalid")
+        else:
+            logger.info(f"Token is for different subdomain: {token_data.get('subdomain')}")
+
+    # No valid token - authenticate via browser
+    token_data = auth_via_browser(subdomain)
+    save_token(token_data)
+    logger.info(f"OAuth token saved for user: {token_data.get('username')}")
+    return token_data
+
+
+# --- Interactive CLI (zendesk-auth command) ---
+
+def auth_sso_browser_interactive(subdomain: str, auth_url: str) -> dict:
+    """Interactive SSO browser flow with stdin fallback."""
+    full_auth_url = _build_auth_url(auth_url)
+    port = _find_free_port()
+    result = {}
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                params = parse_qs(parsed.query)
+                callback_url = params.get("url", [""])[0]
+                token_data = _parse_oauth_callback(callback_url, subdomain)
+                if token_data:
+                    result.update(token_data)
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": True, "username": token_data.get("username")}).encode())
+                    threading.Thread(target=self.server.shutdown, daemon=True).start()
+                else:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"ok": False}).encode())
+            else:
+                html = AUTH_PAGE_HTML.format(auth_url=full_auth_url)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(html.encode())
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    local_url = f"http://127.0.0.1:{port}/auth"
+    print(f"\nOpening browser for Zendesk login...")
+    print(f"If the browser doesn't open, visit: {local_url}\n")
+    webbrowser.open(local_url)
+
+    print("Waiting for authentication...")
+    print("Or paste the callback URL here and press Enter:")
+    print("(Press Ctrl+C to cancel)\n")
+
+    input_result = {}
+
+    def read_stdin():
+        try:
+            line = input("> ").strip()
+            if line and not result:
+                token_data = _parse_oauth_callback(line, subdomain)
+                if token_data:
+                    input_result.update(token_data)
+                    server.shutdown()
+        except (EOFError, KeyboardInterrupt):
+            server.shutdown()
+
+    stdin_thread = threading.Thread(target=read_stdin, daemon=True)
+    stdin_thread.start()
+
+    server_thread.join(timeout=300)
+    server.server_close()
+
+    if result:
+        return result
+    if input_result:
+        return input_result
+    raise RuntimeError("Authentication timed out or was cancelled.")
+
+
 def run_auth_cli():
     """Interactive CLI for authenticating with Zendesk."""
     print("=== Zendesk MCP Server - Authentication ===\n")
@@ -279,7 +454,6 @@ def run_auth_cli():
         print("Error: subdomain is required.")
         sys.exit(1)
 
-    # Remove .zendesk.com suffix if provided
     subdomain = subdomain.replace(".zendesk.com", "").replace("https://", "").replace("http://", "").strip("/")
 
     print(f"\nLooking up authentication options for {subdomain}.zendesk.com...")
@@ -289,7 +463,7 @@ def run_auth_cli():
         if e.response.status_code == 404:
             print(f"Error: subdomain '{subdomain}' not found.")
         elif e.response.status_code == 403:
-            print(f"Error: access to '{subdomain}' is forbidden (IP restriction or mobile access disabled).")
+            print(f"Error: access forbidden (IP restriction or mobile access disabled).")
         else:
             print(f"Error: {e}")
         sys.exit(1)
@@ -299,7 +473,6 @@ def run_auth_cli():
         print("Error: no login methods found for this subdomain.")
         sys.exit(1)
 
-    # Display available auth methods
     print(f"\nAvailable login methods for {lookup.get('name', subdomain)}:")
     for i, login in enumerate(agent_logins):
         service = login.get("service", "unknown")
@@ -311,7 +484,6 @@ def run_auth_cli():
         }.get(service, service)
         print(f"  [{i + 1}] {label}")
 
-    # Choose method
     if len(agent_logins) == 1:
         choice = 0
     else:
@@ -333,19 +505,16 @@ def run_auth_cli():
             print("\nAuthenticating...")
             token_data = auth_email_password(subdomain, email, password)
         else:
-            # SSO/Google/Office365 - use browser flow
-            # Prefer zendesk_url (the mobile SSO endpoint), fall back to url
             auth_url = login.get("zendesk_url") or login.get("url")
             if not auth_url:
                 print("Error: no authentication URL found.")
                 sys.exit(1)
-            token_data = auth_sso_browser(subdomain, auth_url)
+            token_data = auth_sso_browser_interactive(subdomain, auth_url)
     except requests.HTTPError as e:
         print(f"\nAuthentication failed: {e}")
         if e.response is not None:
             try:
-                detail = e.response.json()
-                print(f"Detail: {json.dumps(detail, indent=2)}")
+                print(f"Detail: {json.dumps(e.response.json(), indent=2)}")
             except Exception:
                 print(f"Response: {e.response.text[:500]}")
         sys.exit(1)
@@ -357,7 +526,6 @@ def run_auth_cli():
         print("\nError: no access token received.")
         sys.exit(1)
 
-    # Save token
     path = save_token(token_data)
     print(f"\nAuthentication successful!")
     print(f"  User: {token_data.get('username', 'N/A')}")

--- a/src/zendesk_mcp_server/auth.py
+++ b/src/zendesk_mcp_server/auth.py
@@ -344,7 +344,17 @@ class _UrlSchemeHandler:
         subprocess.run([lsregister, "-f", app_dir], check=True, capture_output=True)
 
         def _cleanup():
+            # Unregister from Launch Services
             subprocess.run([lsregister, "-u", app_dir], capture_output=True)
+            # Also clear the default handler via CoreServices API
+            # (lsregister -u doesn't always work for URL schemes)
+            subprocess.run(
+                ["swift", "-e",
+                 'import Foundation; import CoreServices;'
+                 ' LSSetDefaultHandlerForURLScheme('
+                 '"zendesk-support" as CFString, "" as CFString)'],
+                capture_output=True,
+            )
             shutil.rmtree(app_dir, ignore_errors=True)
 
         self._cleanup_actions.append(_cleanup)

--- a/src/zendesk_mcp_server/auth.py
+++ b/src/zendesk_mcp_server/auth.py
@@ -217,6 +217,59 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def _open_in_private_window(url: str) -> bool:
+    """
+    Open a URL in a private/incognito browser window.
+
+    This prevents the mobile OAuth flow from polluting the user's normal
+    Zendesk browser session with mobile-specific cookies.
+    """
+    try:
+        if sys.platform == "darwin":
+            # Try common browsers in private mode
+            for args in [
+                # Edge (InPrivate)
+                ["open", "-na", "Microsoft Edge", "--args", "--inprivate", url],
+                # Chrome (Incognito)
+                ["open", "-na", "Google Chrome", "--args", "--incognito", url],
+                # Safari (no CLI flag for private, skip)
+                # Firefox
+                ["open", "-na", "Firefox", "--args", "--private-window", url],
+            ]:
+                try:
+                    subprocess.run(args, check=True, capture_output=True, timeout=5)
+                    logger.info(f"Opened private window via: {args[3]}")
+                    return True
+                except (subprocess.CalledProcessError, FileNotFoundError):
+                    continue
+        elif sys.platform == "linux":
+            for args in [
+                ["xdg-open", url],  # Fallback; can't force private easily
+                ["google-chrome", "--incognito", url],
+                ["firefox", "--private-window", url],
+                ["microsoft-edge", "--inprivate", url],
+            ]:
+                try:
+                    subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    return True
+                except FileNotFoundError:
+                    continue
+        elif sys.platform == "win32":
+            for args in [
+                ["cmd", "/c", "start", "msedge", "--inprivate", url],
+                ["cmd", "/c", "start", "chrome", "--incognito", url],
+                ["cmd", "/c", "start", "firefox", "--private-window", url],
+            ]:
+                try:
+                    subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    return True
+                except FileNotFoundError:
+                    continue
+    except Exception as e:
+        logger.warning(f"Failed to open private window: {e}")
+    return False
+
+
 def _parse_oauth_callback(url: str, subdomain: str) -> dict | None:
     """Parse the OAuth callback URL to extract token data."""
     if not url:
@@ -529,15 +582,19 @@ def auth_via_browser(subdomain: str, timeout: int = 300) -> dict:
 
     try:
         if handler_registered:
-            # Handler registered — open the auth URL directly.
-            # The OS will route zendesk-support:// back to our handler.
-            logger.info("URL scheme handler registered. Opening Zendesk login directly.")
-            webbrowser.open(full_auth_url)
+            # Handler registered — open the auth URL directly in a private window.
+            # Using private/incognito prevents the mobile OAuth cookies from
+            # polluting the user's normal Zendesk browser session.
+            logger.info("URL scheme handler registered. Opening Zendesk login in private window.")
+            if not _open_in_private_window(full_auth_url):
+                logger.info("Private window failed, falling back to default browser.")
+                webbrowser.open(full_auth_url)
         else:
             # No handler — open our local page with paste instructions
             local_url = f"http://127.0.0.1:{port}/auth"
             logger.info(f"Opening browser for authentication: {local_url}")
-            webbrowser.open(local_url)
+            if not _open_in_private_window(local_url):
+                webbrowser.open(local_url)
 
         server_thread.join(timeout=timeout)
         server.server_close()

--- a/src/zendesk_mcp_server/auth.py
+++ b/src/zendesk_mcp_server/auth.py
@@ -1,0 +1,378 @@
+"""
+OAuth authentication for Zendesk using the mobile app's OAuth flow.
+
+Supports two auth methods discovered via /api/mobile/account/lookup.json:
+- Email/password: direct POST to /access/oauth_mobile (no browser needed)
+- SSO (SAML/Google/Office365): opens system browser, user pastes callback URL
+
+The access_token is saved to a token file for the MCP server to use.
+"""
+
+import getpass
+import json
+import os
+import platform
+import socket
+import sys
+import threading
+import uuid
+import webbrowser
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import urlencode, urlparse, parse_qs
+
+import requests
+
+CLIENT_ID = "zendesk_support_android"
+OAUTH_SCHEME = "zendesk-support"
+USER_AGENT = "Zendesk-SDK/1.0 Android/30 Variant/Core"
+TOKEN_FILE = ".zendesk_token"
+
+# HTML served by the local callback server after capturing the token
+SUCCESS_HTML = """<!DOCTYPE html>
+<html><head><title>Zendesk Auth</title></head>
+<body style="font-family:sans-serif;text-align:center;padding:60px">
+<h2>Authentication successful!</h2>
+<p>You can close this tab and return to the terminal.</p>
+</body></html>"""
+
+# HTML page that intercepts the custom scheme redirect
+INTERCEPT_HTML = """<!DOCTYPE html>
+<html><head><title>Zendesk Auth</title>
+<script>
+// Listen for navigation to the custom scheme by polling the page location
+// and by intercepting link clicks. The actual mechanism: after SSO completes,
+// Zendesk redirects to zendesk-support://...?access_token=...
+// The browser can't handle this scheme, so we catch it via a service worker
+// or by having the user paste the URL.
+
+// On page load, show instructions
+document.addEventListener('DOMContentLoaded', function() {{
+    document.getElementById('status').textContent = 'Redirecting to Zendesk login...';
+    setTimeout(function() {{
+        window.location.href = '{auth_url}';
+    }}, 1000);
+    // After redirect, show paste instructions (the redirect to custom scheme will fail)
+    setTimeout(function() {{
+        document.getElementById('paste-section').style.display = 'block';
+        document.getElementById('status').textContent =
+            'If you see an error about "zendesk-support://" not being recognized, ' +
+            'copy the full URL from the address bar and paste it below.';
+    }}, 5000);
+}});
+
+function submitUrl() {{
+    var url = document.getElementById('callback-url').value.trim();
+    if (url) {{
+        fetch('/callback?url=' + encodeURIComponent(url))
+            .then(function() {{
+                document.body.innerHTML = '<h2 style="text-align:center;padding:60px;font-family:sans-serif">' +
+                    'Authentication successful! You can close this tab.</h2>';
+            }});
+    }}
+}}
+</script>
+</head>
+<body style="font-family:sans-serif;max-width:600px;margin:40px auto;padding:20px">
+<h2>Zendesk Authentication</h2>
+<p id="status">Initializing...</p>
+<div id="paste-section" style="display:none;margin-top:30px">
+    <p><strong>Paste the callback URL here:</strong></p>
+    <input type="text" id="callback-url" style="width:100%;padding:8px;font-size:14px"
+           placeholder="zendesk-support://?access_token=...">
+    <br><br>
+    <button onclick="submitUrl()" style="padding:10px 20px;font-size:14px;cursor:pointer">
+        Submit
+    </button>
+</div>
+</body></html>"""
+
+
+def get_token_path(project_dir: str = None) -> Path:
+    """Get the path to the token file."""
+    base = Path(project_dir) if project_dir else Path.cwd()
+    return base / TOKEN_FILE
+
+
+def load_token(project_dir: str = None) -> dict | None:
+    """Load saved token from file. Returns dict with access_token, subdomain, etc."""
+    path = get_token_path(project_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        if data.get("access_token") and data.get("subdomain"):
+            return data
+    except (json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+
+def save_token(token_data: dict, project_dir: str = None) -> Path:
+    """Save token data to file."""
+    path = get_token_path(project_dir)
+    path.write_text(json.dumps(token_data, indent=2))
+    path.chmod(0o600)
+    return path
+
+
+def lookup_subdomain(subdomain: str) -> dict:
+    """Call the mobile account lookup endpoint to discover auth methods."""
+    url = f"https://{subdomain}.zendesk.com/api/mobile/account/lookup.json"
+    resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=15)
+    resp.raise_for_status()
+    return resp.json()["lookup"]
+
+
+def auth_email_password(subdomain: str, email: str, password: str) -> dict:
+    """Authenticate with email/password via /access/oauth_mobile."""
+    url = f"https://{subdomain}.zendesk.com/access/oauth_mobile"
+    device_id = str(uuid.uuid4())
+    device_name = platform.node() or "zendesk-mcp"
+    payload = {
+        "clientId": CLIENT_ID,
+        "user": {"email": email, "password": password},
+        "device": {"name": device_name, "identifier": device_id},
+        "nativeMobile": True,
+    }
+    resp = requests.post(
+        url,
+        json=payload,
+        headers={"User-Agent": USER_AGENT, "Content-Type": "application/json"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    auth = data.get("authentication", data)
+    return {
+        "subdomain": subdomain,
+        "access_token": auth.get("accessToken") or auth.get("access_token"),
+        "username": auth.get("username"),
+        "user_id": auth.get("userId") or auth.get("user_id"),
+        "account_id": auth.get("accountId") or auth.get("account_id"),
+        "user_role": auth.get("userRole") or auth.get("user_role"),
+    }
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def auth_sso_browser(subdomain: str, auth_url: str) -> dict:
+    """
+    Authenticate via SSO using the system browser.
+
+    Opens a local HTTP server that:
+    1. Serves a page that redirects to the Zendesk SSO URL
+    2. After SSO, Zendesk redirects to zendesk-support://?access_token=...
+    3. The browser can't handle the custom scheme, so the user pastes the URL
+    4. The local server parses the token and shuts down
+    """
+    port = _find_free_port()
+    result = {}
+    server_ready = threading.Event()
+
+    device_id = str(uuid.uuid4())
+    device_name = platform.node() or "zendesk-mcp"
+    full_auth_url = f"{auth_url}?{urlencode({'client_id': CLIENT_ID, 'device[name]': device_name, 'device[identifier]': device_id})}"
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                params = parse_qs(parsed.query)
+                callback_url = params.get("url", [""])[0]
+                token_data = _parse_oauth_callback(callback_url, subdomain)
+                if token_data:
+                    result.update(token_data)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(SUCCESS_HTML.encode())
+                threading.Thread(target=self.server.shutdown, daemon=True).start()
+            else:
+                # Serve the intercept page
+                html = INTERCEPT_HTML.format(auth_url=full_auth_url)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(html.encode())
+
+        def log_message(self, format, *args):
+            pass  # Suppress HTTP logs
+
+    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    local_url = f"http://127.0.0.1:{port}/auth"
+    print(f"\nOpening browser for Zendesk SSO login...")
+    print(f"If the browser doesn't open, visit: {local_url}\n")
+    webbrowser.open(local_url)
+
+    print("Waiting for authentication...")
+    print("After signing in, if the browser shows an error about 'zendesk-support://',")
+    print("copy the full URL from the address bar and paste it into the browser page.\n")
+    print("Or paste it here and press Enter:")
+    print("(Press Ctrl+C to cancel)\n")
+
+    # Also accept paste from stdin as fallback
+    input_thread_result = {}
+
+    def read_stdin():
+        try:
+            line = input("> ").strip()
+            if line and not result:
+                token_data = _parse_oauth_callback(line, subdomain)
+                if token_data:
+                    input_thread_result.update(token_data)
+                    server.shutdown()
+        except (EOFError, KeyboardInterrupt):
+            server.shutdown()
+
+    stdin_thread = threading.Thread(target=read_stdin, daemon=True)
+    stdin_thread.start()
+
+    server_thread.join(timeout=300)  # 5 min timeout
+    server.server_close()
+
+    if result:
+        return result
+    if input_thread_result:
+        return input_thread_result
+    raise RuntimeError("Authentication timed out or was cancelled.")
+
+
+def _parse_oauth_callback(url: str, subdomain: str) -> dict | None:
+    """Parse the OAuth callback URL to extract token data."""
+    if not url:
+        return None
+    # Handle both zendesk-support://...?params and zendesk-support://?params
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    # Also try fragment (some OAuth flows put params in the fragment)
+    if not params and parsed.fragment:
+        params = parse_qs(parsed.fragment)
+
+    access_token = (params.get("access_token") or [None])[0]
+    if not access_token:
+        return None
+
+    return {
+        "subdomain": subdomain,
+        "access_token": access_token,
+        "username": (params.get("username") or [None])[0],
+        "user_id": (params.get("user_id") or [None])[0],
+        "account_id": (params.get("account_id") or [None])[0],
+        "user_role": (params.get("user_role") or [None])[0],
+    }
+
+
+def run_auth_cli():
+    """Interactive CLI for authenticating with Zendesk."""
+    print("=== Zendesk MCP Server - Authentication ===\n")
+
+    subdomain = input("Enter your Zendesk subdomain (e.g., 'mycompany' for mycompany.zendesk.com): ").strip()
+    if not subdomain:
+        print("Error: subdomain is required.")
+        sys.exit(1)
+
+    # Remove .zendesk.com suffix if provided
+    subdomain = subdomain.replace(".zendesk.com", "").replace("https://", "").replace("http://", "").strip("/")
+
+    print(f"\nLooking up authentication options for {subdomain}.zendesk.com...")
+    try:
+        lookup = lookup_subdomain(subdomain)
+    except requests.HTTPError as e:
+        if e.response.status_code == 404:
+            print(f"Error: subdomain '{subdomain}' not found.")
+        elif e.response.status_code == 403:
+            print(f"Error: access to '{subdomain}' is forbidden (IP restriction or mobile access disabled).")
+        else:
+            print(f"Error: {e}")
+        sys.exit(1)
+
+    agent_logins = lookup.get("agent_logins", [])
+    if not agent_logins:
+        print("Error: no login methods found for this subdomain.")
+        sys.exit(1)
+
+    # Display available auth methods
+    print(f"\nAvailable login methods for {lookup.get('name', subdomain)}:")
+    for i, login in enumerate(agent_logins):
+        service = login.get("service", "unknown")
+        label = {
+            "zendesk": "Email & Password",
+            "google": "Google",
+            "office_365": "Office 365",
+            "remote": "SSO (Corporate)",
+        }.get(service, service)
+        print(f"  [{i + 1}] {label}")
+
+    # Choose method
+    if len(agent_logins) == 1:
+        choice = 0
+    else:
+        try:
+            choice = int(input(f"\nSelect method [1-{len(agent_logins)}]: ").strip()) - 1
+            if choice < 0 or choice >= len(agent_logins):
+                raise ValueError()
+        except (ValueError, EOFError):
+            print("Invalid selection.")
+            sys.exit(1)
+
+    login = agent_logins[choice]
+    service = login.get("service")
+
+    try:
+        if service == "zendesk":
+            email = input("Email: ").strip()
+            password = getpass.getpass("Password: ")
+            print("\nAuthenticating...")
+            token_data = auth_email_password(subdomain, email, password)
+        else:
+            # SSO/Google/Office365 - use browser flow
+            # Prefer zendesk_url (the mobile SSO endpoint), fall back to url
+            auth_url = login.get("zendesk_url") or login.get("url")
+            if not auth_url:
+                print("Error: no authentication URL found.")
+                sys.exit(1)
+            token_data = auth_sso_browser(subdomain, auth_url)
+    except requests.HTTPError as e:
+        print(f"\nAuthentication failed: {e}")
+        if e.response is not None:
+            try:
+                detail = e.response.json()
+                print(f"Detail: {json.dumps(detail, indent=2)}")
+            except Exception:
+                print(f"Response: {e.response.text[:500]}")
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"\n{e}")
+        sys.exit(1)
+
+    if not token_data.get("access_token"):
+        print("\nError: no access token received.")
+        sys.exit(1)
+
+    # Save token
+    path = save_token(token_data)
+    print(f"\nAuthentication successful!")
+    print(f"  User: {token_data.get('username', 'N/A')}")
+    print(f"  Role: {token_data.get('user_role', 'N/A')}")
+    print(f"  Token saved to: {path}")
+    print(f"\nThe MCP server will use this token automatically on next start.")
+
+
+def main():
+    try:
+        run_auth_cli()
+    except KeyboardInterrupt:
+        print("\n\nCancelled.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -25,7 +25,8 @@ load_dotenv()
 zendesk_client = ZendeskClient(
     subdomain=os.getenv("ZENDESK_SUBDOMAIN"),
     email=os.getenv("ZENDESK_EMAIL"),
-    token=os.getenv("ZENDESK_API_KEY")
+    token=os.getenv("ZENDESK_API_KEY"),
+    session_cookie=os.getenv("ZENDESK_SESSION_COOKIE"),
 )
 
 server = Server("Zendesk Server")

--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -309,7 +309,180 @@ async def handle_list_tools() -> list[types.Tool]:
                 },
                 "required": ["ticket_id"]
             }
-        )
+        ),
+        # ── P0: Search & Users ──────────────────────────────────────
+        types.Tool(
+            name="search",
+            description="Search Zendesk using Zendesk Query Language (ZQL). Searches tickets, users, and organizations. Example queries: 'type:ticket status:open priority:urgent', 'type:ticket assignee:me', 'type:user email:john@example.com'",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "ZQL search query"},
+                    "page": {"type": "integer", "default": 1},
+                    "per_page": {"type": "integer", "default": 25, "description": "Results per page (max 100)"},
+                    "sort_by": {"type": "string", "default": "relevance", "description": "relevance, updated_at, created_at, priority, status, ticket_type"},
+                    "sort_order": {"type": "string", "default": "desc", "description": "asc or desc"},
+                },
+                "required": ["query"],
+            }
+        ),
+        types.Tool(
+            name="get_user",
+            description="Get a Zendesk user by their ID. Use this to resolve requester_id or assignee_id from tickets.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "integer", "description": "The user ID"}
+                },
+                "required": ["user_id"],
+            }
+        ),
+        types.Tool(
+            name="get_current_user",
+            description="Get the currently authenticated Zendesk user",
+            inputSchema={"type": "object", "properties": {}}
+        ),
+        types.Tool(
+            name="search_users",
+            description="Search Zendesk users by name, email, or external_id",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Name, email, or external_id to search for"}
+                },
+                "required": ["query"],
+            }
+        ),
+        # ── P1: Views, Fields, Orgs, Bulk ───────────────────────────
+        types.Tool(
+            name="list_views",
+            description="List all available Zendesk views (saved ticket queues)",
+            inputSchema={"type": "object", "properties": {}}
+        ),
+        types.Tool(
+            name="execute_view",
+            description="Execute a Zendesk view and return its tickets",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "view_id": {"type": "integer", "description": "The view ID to execute"},
+                    "page": {"type": "integer", "default": 1},
+                    "per_page": {"type": "integer", "default": 25},
+                },
+                "required": ["view_id"],
+            }
+        ),
+        types.Tool(
+            name="list_ticket_fields",
+            description="List all ticket fields (system + custom) with their types and valid options",
+            inputSchema={"type": "object", "properties": {}}
+        ),
+        types.Tool(
+            name="get_organization",
+            description="Get a Zendesk organization by its ID",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "organization_id": {"type": "integer", "description": "The organization ID"}
+                },
+                "required": ["organization_id"],
+            }
+        ),
+        types.Tool(
+            name="search_organizations",
+            description="Search Zendesk organizations by name",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Organization name to search for"}
+                },
+                "required": ["query"],
+            }
+        ),
+        types.Tool(
+            name="get_tickets_bulk",
+            description="Fetch multiple tickets by IDs in a single request (max 100)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ticket_ids": {"type": "array", "items": {"type": "integer"}, "description": "List of ticket IDs"}
+                },
+                "required": ["ticket_ids"],
+            }
+        ),
+        # ── P2: Groups, Merge, Macros ───────────────────────────────
+        types.Tool(
+            name="list_groups",
+            description="List assignable Zendesk groups for ticket routing",
+            inputSchema={"type": "object", "properties": {}}
+        ),
+        types.Tool(
+            name="merge_tickets",
+            description="Merge source tickets into a target ticket",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "target_id": {"type": "integer", "description": "The ticket to merge into"},
+                    "source_ids": {"type": "array", "items": {"type": "integer"}, "description": "Tickets to merge from"},
+                    "target_comment": {"type": "string", "default": "Merged from related tickets."},
+                    "source_comment": {"type": "string", "default": "This ticket has been merged."},
+                },
+                "required": ["target_id", "source_ids"],
+            }
+        ),
+        types.Tool(
+            name="list_macros",
+            description="List available Zendesk macros (canned responses and actions)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "active_only": {"type": "boolean", "default": True}
+                },
+            }
+        ),
+        types.Tool(
+            name="apply_macro",
+            description="Preview the result of applying a macro to a ticket (does not save changes)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ticket_id": {"type": "integer", "description": "The ticket to apply the macro to"},
+                    "macro_id": {"type": "integer", "description": "The macro to apply"},
+                },
+                "required": ["ticket_id", "macro_id"],
+            }
+        ),
+        # ── P3: User Tickets, Forms, Delete ─────────────────────────
+        types.Tool(
+            name="get_user_tickets",
+            description="Get tickets for a specific user by role (requested, assigned, or ccd)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "integer", "description": "The user ID"},
+                    "role": {"type": "string", "default": "requested", "description": "requested, assigned, or ccd"},
+                    "page": {"type": "integer", "default": 1},
+                    "per_page": {"type": "integer", "default": 25},
+                },
+                "required": ["user_id"],
+            }
+        ),
+        types.Tool(
+            name="list_ticket_forms",
+            description="List all ticket forms and their associated field IDs",
+            inputSchema={"type": "object", "properties": {}}
+        ),
+        types.Tool(
+            name="delete_ticket",
+            description="Permanently delete a Zendesk ticket. Use with caution.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ticket_id": {"type": "integer", "description": "The ticket ID to delete"}
+                },
+                "required": ["ticket_id"],
+            }
+        ),
     ]
 
 
@@ -417,6 +590,124 @@ async def handle_call_tool(
                 type="text",
                 text=json.dumps({"message": "Ticket updated successfully", "ticket": updated}, indent=2)
             )]
+
+        # ── P0: Search & Users ──────────────────────────────────────
+        elif name == "search":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            result = zendesk_client.search(
+                query=arguments["query"],
+                page=arguments.get("page", 1),
+                per_page=arguments.get("per_page", 25),
+                sort_by=arguments.get("sort_by", "relevance"),
+                sort_order=arguments.get("sort_order", "desc"),
+            )
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == "get_user":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            user = zendesk_client.get_user(arguments["user_id"])
+            return [types.TextContent(type="text", text=json.dumps(user, indent=2))]
+
+        elif name == "get_current_user":
+            user = zendesk_client.get_current_user()
+            return [types.TextContent(type="text", text=json.dumps(user, indent=2))]
+
+        elif name == "search_users":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            users = zendesk_client.search_users(arguments["query"])
+            return [types.TextContent(type="text", text=json.dumps(users, indent=2))]
+
+        # ── P1: Views, Fields, Orgs, Bulk ───────────────────────────
+        elif name == "list_views":
+            views = zendesk_client.list_views()
+            return [types.TextContent(type="text", text=json.dumps(views, indent=2))]
+
+        elif name == "execute_view":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            result = zendesk_client.execute_view(
+                view_id=arguments["view_id"],
+                page=arguments.get("page", 1),
+                per_page=arguments.get("per_page", 25),
+            )
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == "list_ticket_fields":
+            fields = zendesk_client.list_ticket_fields()
+            return [types.TextContent(type="text", text=json.dumps(fields, indent=2))]
+
+        elif name == "get_organization":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            org = zendesk_client.get_organization(arguments["organization_id"])
+            return [types.TextContent(type="text", text=json.dumps(org, indent=2))]
+
+        elif name == "search_organizations":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            orgs = zendesk_client.search_organizations(arguments["query"])
+            return [types.TextContent(type="text", text=json.dumps(orgs, indent=2))]
+
+        elif name == "get_tickets_bulk":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            tickets = zendesk_client.get_tickets_bulk(arguments["ticket_ids"])
+            return [types.TextContent(type="text", text=json.dumps(tickets, indent=2))]
+
+        # ── P2: Groups, Merge, Macros ───────────────────────────────
+        elif name == "list_groups":
+            groups = zendesk_client.list_groups()
+            return [types.TextContent(type="text", text=json.dumps(groups, indent=2))]
+
+        elif name == "merge_tickets":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            result = zendesk_client.merge_tickets(
+                target_id=arguments["target_id"],
+                source_ids=arguments["source_ids"],
+                target_comment=arguments.get("target_comment", "Merged from related tickets."),
+                source_comment=arguments.get("source_comment", "This ticket has been merged."),
+            )
+            return [types.TextContent(type="text", text=json.dumps({"message": "Tickets merged successfully", "result": result}, indent=2))]
+
+        elif name == "list_macros":
+            active_only = arguments.get("active_only", True) if arguments else True
+            macros = zendesk_client.list_macros(active_only=active_only)
+            return [types.TextContent(type="text", text=json.dumps(macros, indent=2))]
+
+        elif name == "apply_macro":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            result = zendesk_client.apply_macro(
+                ticket_id=arguments["ticket_id"],
+                macro_id=arguments["macro_id"],
+            )
+            return [types.TextContent(type="text", text=json.dumps({"message": "Macro preview (not saved)", "result": result}, indent=2))]
+
+        # ── P3: User Tickets, Forms, Delete ─────────────────────────
+        elif name == "get_user_tickets":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            result = zendesk_client.get_user_tickets(
+                user_id=arguments["user_id"],
+                role=arguments.get("role", "requested"),
+                page=arguments.get("page", 1),
+                per_page=arguments.get("per_page", 25),
+            )
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == "list_ticket_forms":
+            forms = zendesk_client.list_ticket_forms()
+            return [types.TextContent(type="text", text=json.dumps(forms, indent=2))]
+
+        elif name == "delete_ticket":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            zendesk_client.delete_ticket(arguments["ticket_id"])
+            return [types.TextContent(type="text", text=json.dumps({"message": f"Ticket {arguments['ticket_id']} deleted successfully"}))]
 
         else:
             raise ValueError(f"Unknown tool: {name}")

--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -23,29 +23,61 @@ logger.info("zendesk mcp server started")
 
 load_dotenv()
 
-# Try to load OAuth token from token file first
-_oauth_token = None
-_oauth_subdomain = None
-try:
-    from zendesk_mcp_server.auth import load_token
-    _token_data = load_token(os.path.dirname(os.path.abspath(__file__ + "/../..")))
-    if not _token_data:
-        # Also try the working directory
-        _token_data = load_token()
-    if _token_data:
-        _oauth_token = _token_data.get("access_token")
-        _oauth_subdomain = _token_data.get("subdomain")
-        logger.info("Loaded OAuth token from token file")
-except Exception:
-    pass
 
-zendesk_client = ZendeskClient(
-    subdomain=os.getenv("ZENDESK_SUBDOMAIN") or _oauth_subdomain,
-    email=os.getenv("ZENDESK_EMAIL"),
-    token=os.getenv("ZENDESK_API_KEY"),
-    session_cookie=os.getenv("ZENDESK_SESSION_COOKIE"),
-    oauth_access_token=os.getenv("ZENDESK_OAUTH_TOKEN") or _oauth_token,
-)
+def _init_client() -> ZendeskClient:
+    """
+    Initialize the Zendesk client with the best available auth method.
+
+    Priority:
+    1. Env var ZENDESK_OAUTH_TOKEN or ZENDESK_API_KEY (explicit config)
+    2. Saved OAuth token from .zendesk_token file
+    3. Browser-based OAuth flow (opens browser for login)
+    """
+    from zendesk_mcp_server.auth import ensure_auth, load_token
+
+    subdomain = os.getenv("ZENDESK_SUBDOMAIN")
+    email = os.getenv("ZENDESK_EMAIL")
+    api_key = os.getenv("ZENDESK_API_KEY")
+    oauth_token = os.getenv("ZENDESK_OAUTH_TOKEN")
+    session_cookie = os.getenv("ZENDESK_SESSION_COOKIE")
+
+    # If explicit credentials are set, use them directly
+    if oauth_token or (email and api_key) or session_cookie:
+        oauth_from_file = None
+        if not oauth_token:
+            token_data = load_token()
+            if token_data:
+                oauth_from_file = token_data.get("access_token")
+                subdomain = subdomain or token_data.get("subdomain")
+        return ZendeskClient(
+            subdomain=subdomain,
+            email=email,
+            token=api_key,
+            session_cookie=session_cookie,
+            oauth_access_token=oauth_token or oauth_from_file,
+        )
+
+    # No explicit credentials - try token file, then browser auth
+    if not subdomain:
+        # Check if token file has a subdomain
+        token_data = load_token()
+        if token_data:
+            subdomain = token_data.get("subdomain")
+
+    if not subdomain:
+        raise ValueError(
+            "ZENDESK_SUBDOMAIN is required. Set it in .env or run 'zendesk-auth'."
+        )
+
+    # ensure_auth will check existing token, verify it, or open browser
+    token_data = ensure_auth(subdomain)
+    return ZendeskClient(
+        subdomain=subdomain,
+        oauth_access_token=token_data["access_token"],
+    )
+
+
+zendesk_client = _init_client()
 
 server = Server("Zendesk Server")
 

--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -22,11 +22,29 @@ logger = logging.getLogger("zendesk-mcp-server")
 logger.info("zendesk mcp server started")
 
 load_dotenv()
+
+# Try to load OAuth token from token file first
+_oauth_token = None
+_oauth_subdomain = None
+try:
+    from zendesk_mcp_server.auth import load_token
+    _token_data = load_token(os.path.dirname(os.path.abspath(__file__ + "/../..")))
+    if not _token_data:
+        # Also try the working directory
+        _token_data = load_token()
+    if _token_data:
+        _oauth_token = _token_data.get("access_token")
+        _oauth_subdomain = _token_data.get("subdomain")
+        logger.info("Loaded OAuth token from token file")
+except Exception:
+    pass
+
 zendesk_client = ZendeskClient(
-    subdomain=os.getenv("ZENDESK_SUBDOMAIN"),
+    subdomain=os.getenv("ZENDESK_SUBDOMAIN") or _oauth_subdomain,
     email=os.getenv("ZENDESK_EMAIL"),
     token=os.getenv("ZENDESK_API_KEY"),
     session_cookie=os.getenv("ZENDESK_SESSION_COOKIE"),
+    oauth_access_token=os.getenv("ZENDESK_OAUTH_TOKEN") or _oauth_token,
 )
 
 server = Server("Zendesk Server")

--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -1,6 +1,5 @@
 from typing import Dict, Any, List
 import json
-import urllib.request
 import urllib.parse
 import base64
 import logging
@@ -11,22 +10,37 @@ logger = logging.getLogger("zendesk-mcp-server")
 
 class ZendeskClient:
     def __init__(self, subdomain: str, email: str = None, token: str = None,
-                 session_cookie: str = None):
+                 session_cookie: str = None, oauth_access_token: str = None):
         """
         Initialize the Zendesk client.
 
-        Supports two auth modes:
-        - Token auth: requires email + token (uses zenpy + Basic auth)
-        - Cookie auth: requires session_cookie (uses direct HTTP with browser session)
+        Supports three auth modes (checked in order):
+        - OAuth token: requires oauth_access_token (Bearer token from mobile OAuth flow)
+        - API token: requires email + token (Basic auth with email/token:key)
+        - Cookie auth: requires session_cookie (browser session cookie)
         """
         self.subdomain = subdomain
         self.base_url = f"https://{subdomain}.zendesk.com/api/v2"
-        self.email = email
-        self.token = token
-        self.session_cookie = session_cookie
-        self._use_cookies = bool(session_cookie) and not (email and token)
 
-        if self._use_cookies:
+        if oauth_access_token:
+            logger.info("Using OAuth Bearer token authentication")
+            self._session = _requests.Session()
+            self._session.headers.update({
+                'Authorization': f'Bearer {oauth_access_token}',
+                'Content-Type': 'application/json',
+            })
+            self.auth_header = f'Bearer {oauth_access_token}'
+        elif email and token:
+            logger.info("Using API token authentication")
+            credentials = f"{email}/token:{token}"
+            encoded_credentials = base64.b64encode(credentials.encode()).decode('ascii')
+            self.auth_header = f"Basic {encoded_credentials}"
+            self._session = _requests.Session()
+            self._session.headers.update({
+                'Authorization': self.auth_header,
+                'Content-Type': 'application/json',
+            })
+        elif session_cookie:
             logger.info("Using cookie-based authentication")
             self._session = _requests.Session()
             self._session.cookies.set(
@@ -36,64 +50,31 @@ class ZendeskClient:
             self._session.headers.update({
                 'Content-Type': 'application/json',
             })
-            self.client = None
             self.auth_header = None
         else:
-            logger.info("Using token-based authentication")
-            from zenpy import Zenpy
-            self.client = Zenpy(
-                subdomain=subdomain,
-                email=email,
-                token=token
+            raise ValueError(
+                "No authentication configured. Provide one of: "
+                "oauth_access_token, email+token, or session_cookie. "
+                "Run 'zendesk-auth' to authenticate via OAuth."
             )
-            credentials = f"{email}/token:{token}"
-            encoded_credentials = base64.b64encode(credentials.encode()).decode('ascii')
-            self.auth_header = f"Basic {encoded_credentials}"
-            self._session = None
 
     def _api_get(self, path: str) -> Dict[str, Any]:
         """Make a GET request to the Zendesk API."""
-        url = f"{self.base_url}/{path}"
-        if self._use_cookies:
-            resp = self._session.get(url, timeout=30)
-            resp.raise_for_status()
-            return resp.json()
-        else:
-            req = urllib.request.Request(url)
-            req.add_header('Authorization', self.auth_header)
-            req.add_header('Content-Type', 'application/json')
-            with urllib.request.urlopen(req) as response:
-                return json.loads(response.read().decode())
+        resp = self._session.get(f"{self.base_url}/{path}", timeout=30)
+        resp.raise_for_status()
+        return resp.json()
 
     def _api_put(self, path: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Make a PUT request to the Zendesk API."""
-        url = f"{self.base_url}/{path}"
-        if self._use_cookies:
-            resp = self._session.put(url, json=data, timeout=30)
-            resp.raise_for_status()
-            return resp.json()
-        else:
-            body = json.dumps(data).encode()
-            req = urllib.request.Request(url, data=body, method='PUT')
-            req.add_header('Authorization', self.auth_header)
-            req.add_header('Content-Type', 'application/json')
-            with urllib.request.urlopen(req) as response:
-                return json.loads(response.read().decode())
+        resp = self._session.put(f"{self.base_url}/{path}", json=data, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
 
     def _api_post(self, path: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Make a POST request to the Zendesk API."""
-        url = f"{self.base_url}/{path}"
-        if self._use_cookies:
-            resp = self._session.post(url, json=data, timeout=30)
-            resp.raise_for_status()
-            return resp.json()
-        else:
-            body = json.dumps(data).encode()
-            req = urllib.request.Request(url, data=body, method='POST')
-            req.add_header('Authorization', self.auth_header)
-            req.add_header('Content-Type', 'application/json')
-            with urllib.request.urlopen(req) as response:
-                return json.loads(response.read().decode())
+        resp = self._session.post(f"{self.base_url}/{path}", json=data, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
 
     def get_ticket(self, ticket_id: int) -> Dict[str, Any]:
         """
@@ -175,19 +156,11 @@ class ZendeskClient:
         which is required — the CDN returns 403 if it receives an auth header.
         """
         try:
-            if self._use_cookies:
-                response = self._session.get(
-                    content_url,
-                    timeout=30,
-                    stream=True,
-                )
-            else:
-                response = _requests.get(
-                    content_url,
-                    headers={'Authorization': self.auth_header},
-                    timeout=30,
-                    stream=True,
-                )
+            response = self._session.get(
+                content_url,
+                timeout=30,
+                stream=True,
+            )
             response.raise_for_status()
 
             content_type = response.headers.get('Content-Type', '').split(';')[0].strip().lower()
@@ -310,30 +283,16 @@ class ZendeskClient:
         """
         try:
             sections_url = f"https://{self.subdomain}.zendesk.com/api/v2/help_center/sections.json"
-            if self._use_cookies:
-                resp = self._session.get(sections_url, timeout=30)
-                resp.raise_for_status()
-                sections_data = resp.json()
-            else:
-                req = urllib.request.Request(sections_url)
-                req.add_header('Authorization', self.auth_header)
-                req.add_header('Content-Type', 'application/json')
-                with urllib.request.urlopen(req) as response:
-                    sections_data = json.loads(response.read().decode())
+            resp = self._session.get(sections_url, timeout=30)
+            resp.raise_for_status()
+            sections_data = resp.json()
 
             kb = {}
             for section in sections_data.get('sections', []):
                 articles_url = f"https://{self.subdomain}.zendesk.com/api/v2/help_center/sections/{section['id']}/articles.json"
-                if self._use_cookies:
-                    resp = self._session.get(articles_url, timeout=30)
-                    resp.raise_for_status()
-                    articles_data = resp.json()
-                else:
-                    req = urllib.request.Request(articles_url)
-                    req.add_header('Authorization', self.auth_header)
-                    req.add_header('Content-Type', 'application/json')
-                    with urllib.request.urlopen(req) as response:
-                        articles_data = json.loads(response.read().decode())
+                resp = self._session.get(articles_url, timeout=30)
+                resp.raise_for_status()
+                articles_data = resp.json()
 
                 kb[section.get('name', '')] = {
                     'section_id': section['id'],

--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -76,6 +76,11 @@ class ZendeskClient:
         resp.raise_for_status()
         return resp.json()
 
+    def _api_delete(self, path: str) -> None:
+        """Make a DELETE request to the Zendesk API."""
+        resp = self._session.delete(f"{self.base_url}/{path}", timeout=30)
+        resp.raise_for_status()
+
     def get_ticket(self, ticket_id: int) -> Dict[str, Any]:
         """
         Query a ticket by its ID
@@ -394,3 +399,266 @@ class ZendeskClient:
             }
         except Exception as e:
             raise Exception(f"Failed to update ticket {ticket_id}: {str(e)}")
+
+    # ── P0: Search & Users ──────────────────────────────────────────────
+
+    def search(self, query: str, page: int = 1, per_page: int = 25,
+               sort_by: str = 'relevance', sort_order: str = 'desc') -> Dict[str, Any]:
+        """Search tickets, users, orgs using Zendesk Query Language (ZQL)."""
+        try:
+            per_page = min(per_page, 100)
+            params = urllib.parse.urlencode({
+                'query': query, 'page': str(page),
+                'per_page': str(per_page),
+                'sort_by': sort_by, 'sort_order': sort_order,
+            })
+            data = self._api_get(f"search.json?{params}")
+            return {
+                'results': data.get('results', []),
+                'count': data.get('count', 0),
+                'page': page,
+                'per_page': per_page,
+                'has_more': data.get('next_page') is not None,
+            }
+        except Exception as e:
+            raise Exception(f"Search failed: {str(e)}")
+
+    def get_user(self, user_id: int) -> Dict[str, Any]:
+        """Get a user by ID."""
+        try:
+            data = self._api_get(f"users/{user_id}.json")
+            u = data['user']
+            return {
+                'id': u.get('id'), 'name': u.get('name'),
+                'email': u.get('email'), 'role': u.get('role'),
+                'phone': u.get('phone'), 'photo_url': (u.get('photo') or {}).get('content_url'),
+                'organization_id': u.get('organization_id'),
+                'time_zone': u.get('time_zone'),
+                'active': u.get('active'), 'suspended': u.get('suspended'),
+                'created_at': u.get('created_at'), 'updated_at': u.get('updated_at'),
+                'tags': u.get('tags', []),
+            }
+        except Exception as e:
+            raise Exception(f"Failed to get user {user_id}: {str(e)}")
+
+    def get_current_user(self) -> Dict[str, Any]:
+        """Get the currently authenticated user."""
+        try:
+            data = self._api_get("users/me.json")
+            u = data['user']
+            return {
+                'id': u.get('id'), 'name': u.get('name'),
+                'email': u.get('email'), 'role': u.get('role'),
+                'organization_id': u.get('organization_id'),
+                'time_zone': u.get('time_zone'),
+                'default_group_id': u.get('default_group_id'),
+            }
+        except Exception as e:
+            raise Exception(f"Failed to get current user: {str(e)}")
+
+    def search_users(self, query: str) -> List[Dict[str, Any]]:
+        """Search users by name, email, or external_id."""
+        try:
+            params = urllib.parse.urlencode({'query': query})
+            data = self._api_get(f"users/search.json?{params}")
+            return [{
+                'id': u.get('id'), 'name': u.get('name'),
+                'email': u.get('email'), 'role': u.get('role'),
+                'organization_id': u.get('organization_id'),
+                'active': u.get('active'),
+            } for u in data.get('users', [])]
+        except Exception as e:
+            raise Exception(f"User search failed: {str(e)}")
+
+    # ── P1: Views, Fields, Orgs, Bulk ───────────────────────────────────
+
+    def list_views(self) -> List[Dict[str, Any]]:
+        """List all available views."""
+        try:
+            data = self._api_get("views.json")
+            return [{
+                'id': v.get('id'), 'title': v.get('title'),
+                'active': v.get('active'),
+                'position': v.get('position'),
+            } for v in data.get('views', [])]
+        except Exception as e:
+            raise Exception(f"Failed to list views: {str(e)}")
+
+    def execute_view(self, view_id: int, page: int = 1, per_page: int = 25) -> Dict[str, Any]:
+        """Execute a view and return its tickets."""
+        try:
+            per_page = min(per_page, 100)
+            params = urllib.parse.urlencode({'page': str(page), 'per_page': str(per_page)})
+            data = self._api_get(f"views/{view_id}/tickets.json?{params}")
+            return {
+                'tickets': [{
+                    'id': t.get('id'), 'subject': t.get('subject'),
+                    'status': t.get('status'), 'priority': t.get('priority'),
+                    'requester_id': t.get('requester_id'),
+                    'assignee_id': t.get('assignee_id'),
+                    'group_id': t.get('group_id'),
+                    'created_at': t.get('created_at'),
+                    'updated_at': t.get('updated_at'),
+                } for t in data.get('tickets', [])],
+                'count': len(data.get('tickets', [])),
+                'has_more': data.get('next_page') is not None,
+            }
+        except Exception as e:
+            raise Exception(f"Failed to execute view {view_id}: {str(e)}")
+
+    def list_ticket_fields(self) -> List[Dict[str, Any]]:
+        """List all ticket fields (system + custom)."""
+        try:
+            data = self._api_get("ticket_fields.json")
+            return [{
+                'id': f.get('id'), 'title': f.get('title'),
+                'type': f.get('type'), 'active': f.get('active'),
+                'required': f.get('required'),
+                'custom_field_options': [
+                    {'name': o.get('name'), 'value': o.get('value')}
+                    for o in f.get('custom_field_options', [])
+                ] if f.get('custom_field_options') else None,
+            } for f in data.get('ticket_fields', [])]
+        except Exception as e:
+            raise Exception(f"Failed to list ticket fields: {str(e)}")
+
+    def get_organization(self, org_id: int) -> Dict[str, Any]:
+        """Get an organization by ID."""
+        try:
+            data = self._api_get(f"organizations/{org_id}.json")
+            o = data['organization']
+            return {
+                'id': o.get('id'), 'name': o.get('name'),
+                'domain_names': o.get('domain_names', []),
+                'details': o.get('details'), 'notes': o.get('notes'),
+                'group_id': o.get('group_id'),
+                'tags': o.get('tags', []),
+                'created_at': o.get('created_at'),
+                'updated_at': o.get('updated_at'),
+            }
+        except Exception as e:
+            raise Exception(f"Failed to get organization {org_id}: {str(e)}")
+
+    def search_organizations(self, query: str) -> List[Dict[str, Any]]:
+        """Search organizations by name or external_id."""
+        try:
+            params = urllib.parse.urlencode({'name': query})
+            data = self._api_get(f"organizations/autocomplete.json?{params}")
+            return [{
+                'id': o.get('id'), 'name': o.get('name'),
+                'domain_names': o.get('domain_names', []),
+            } for o in data.get('organizations', [])]
+        except Exception as e:
+            raise Exception(f"Organization search failed: {str(e)}")
+
+    def get_tickets_bulk(self, ticket_ids: List[int]) -> List[Dict[str, Any]]:
+        """Fetch multiple tickets by IDs in a single request (max 100)."""
+        try:
+            ids_str = ','.join(str(i) for i in ticket_ids[:100])
+            data = self._api_get(f"tickets/show_many.json?ids={ids_str}")
+            return [{
+                'id': t.get('id'), 'subject': t.get('subject'),
+                'status': t.get('status'), 'priority': t.get('priority'),
+                'requester_id': t.get('requester_id'),
+                'assignee_id': t.get('assignee_id'),
+                'group_id': t.get('group_id'),
+                'created_at': t.get('created_at'),
+                'updated_at': t.get('updated_at'),
+            } for t in data.get('tickets', [])]
+        except Exception as e:
+            raise Exception(f"Bulk ticket fetch failed: {str(e)}")
+
+    # ── P2: Groups, Merge, Macros ───────────────────────────────────────
+
+    def list_groups(self) -> List[Dict[str, Any]]:
+        """List assignable groups."""
+        try:
+            data = self._api_get("groups/assignable.json")
+            return [{
+                'id': g.get('id'), 'name': g.get('name'),
+                'description': g.get('description'),
+            } for g in data.get('groups', [])]
+        except Exception as e:
+            raise Exception(f"Failed to list groups: {str(e)}")
+
+    def merge_tickets(self, target_id: int, source_ids: List[int],
+                      target_comment: str = "Merged from related tickets.",
+                      source_comment: str = "This ticket has been merged.") -> Dict[str, Any]:
+        """Merge source tickets into a target ticket."""
+        try:
+            data = {
+                "ids": source_ids,
+                "target_comment": target_comment,
+                "source_comment": source_comment,
+            }
+            result = self._api_post(f"tickets/{target_id}/merge.json", data)
+            return result
+        except Exception as e:
+            raise Exception(f"Failed to merge tickets into {target_id}: {str(e)}")
+
+    def list_macros(self, active_only: bool = True) -> List[Dict[str, Any]]:
+        """List available macros."""
+        try:
+            path = "macros/active.json" if active_only else "macros.json"
+            data = self._api_get(path)
+            return [{
+                'id': m.get('id'), 'title': m.get('title'),
+                'description': m.get('description'),
+                'active': m.get('active'),
+            } for m in data.get('macros', [])]
+        except Exception as e:
+            raise Exception(f"Failed to list macros: {str(e)}")
+
+    def apply_macro(self, ticket_id: int, macro_id: int) -> Dict[str, Any]:
+        """Preview the result of applying a macro to a ticket."""
+        try:
+            data = self._api_get(f"tickets/{ticket_id}/macros/{macro_id}/apply.json")
+            result = data.get('result', {})
+            ticket = result.get('ticket', {})
+            return {
+                'ticket_changes': ticket,
+                'comment': result.get('comment'),
+            }
+        except Exception as e:
+            raise Exception(f"Failed to apply macro {macro_id} to ticket {ticket_id}: {str(e)}")
+
+    # ── P3: User Tickets, Forms, Delete ─────────────────────────────────
+
+    def get_user_tickets(self, user_id: int, role: str = 'requested',
+                         page: int = 1, per_page: int = 25) -> Dict[str, Any]:
+        """Get tickets for a user. role: 'requested', 'assigned', or 'ccd'."""
+        try:
+            per_page = min(per_page, 100)
+            params = urllib.parse.urlencode({'page': str(page), 'per_page': str(per_page)})
+            data = self._api_get(f"users/{user_id}/tickets/{role}.json?{params}")
+            return {
+                'tickets': [{
+                    'id': t.get('id'), 'subject': t.get('subject'),
+                    'status': t.get('status'), 'priority': t.get('priority'),
+                    'created_at': t.get('created_at'),
+                    'updated_at': t.get('updated_at'),
+                } for t in data.get('tickets', [])],
+                'has_more': data.get('next_page') is not None,
+            }
+        except Exception as e:
+            raise Exception(f"Failed to get tickets for user {user_id}: {str(e)}")
+
+    def list_ticket_forms(self) -> List[Dict[str, Any]]:
+        """List all ticket forms."""
+        try:
+            data = self._api_get("ticket_forms.json")
+            return [{
+                'id': f.get('id'), 'name': f.get('name'),
+                'display_name': f.get('display_name'),
+                'active': f.get('active'), 'default': f.get('default'),
+                'ticket_field_ids': f.get('ticket_field_ids', []),
+            } for f in data.get('ticket_forms', [])]
+        except Exception as e:
+            raise Exception(f"Failed to list ticket forms: {str(e)}")
+
+    def delete_ticket(self, ticket_id: int) -> None:
+        """Permanently delete a ticket."""
+        try:
+            self._api_delete(f"tickets/{ticket_id}.json")
+        except Exception as e:
+            raise Exception(f"Failed to delete ticket {ticket_id}: {str(e)}")

--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -3,51 +3,116 @@ import json
 import urllib.request
 import urllib.parse
 import base64
+import logging
 import requests as _requests
 
-from zenpy import Zenpy
-from zenpy.lib.api_objects import Comment
-from zenpy.lib.api_objects import Ticket as ZenpyTicket
+logger = logging.getLogger("zendesk-mcp-server")
 
 
 class ZendeskClient:
-    def __init__(self, subdomain: str, email: str, token: str):
+    def __init__(self, subdomain: str, email: str = None, token: str = None,
+                 session_cookie: str = None):
         """
-        Initialize the Zendesk client using zenpy lib and direct API.
-        """
-        self.client = Zenpy(
-            subdomain=subdomain,
-            email=email,
-            token=token
-        )
+        Initialize the Zendesk client.
 
-        # For direct API calls
+        Supports two auth modes:
+        - Token auth: requires email + token (uses zenpy + Basic auth)
+        - Cookie auth: requires session_cookie (uses direct HTTP with browser session)
+        """
         self.subdomain = subdomain
+        self.base_url = f"https://{subdomain}.zendesk.com/api/v2"
         self.email = email
         self.token = token
-        self.base_url = f"https://{subdomain}.zendesk.com/api/v2"
-        # Create basic auth header
-        credentials = f"{email}/token:{token}"
-        encoded_credentials = base64.b64encode(credentials.encode()).decode('ascii')
-        self.auth_header = f"Basic {encoded_credentials}"
+        self.session_cookie = session_cookie
+        self._use_cookies = bool(session_cookie) and not (email and token)
+
+        if self._use_cookies:
+            logger.info("Using cookie-based authentication")
+            self._session = _requests.Session()
+            self._session.cookies.set(
+                '_zendesk_session', session_cookie,
+                domain=f'{subdomain}.zendesk.com'
+            )
+            self._session.headers.update({
+                'Content-Type': 'application/json',
+            })
+            self.client = None
+            self.auth_header = None
+        else:
+            logger.info("Using token-based authentication")
+            from zenpy import Zenpy
+            self.client = Zenpy(
+                subdomain=subdomain,
+                email=email,
+                token=token
+            )
+            credentials = f"{email}/token:{token}"
+            encoded_credentials = base64.b64encode(credentials.encode()).decode('ascii')
+            self.auth_header = f"Basic {encoded_credentials}"
+            self._session = None
+
+    def _api_get(self, path: str) -> Dict[str, Any]:
+        """Make a GET request to the Zendesk API."""
+        url = f"{self.base_url}/{path}"
+        if self._use_cookies:
+            resp = self._session.get(url, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        else:
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                return json.loads(response.read().decode())
+
+    def _api_put(self, path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Make a PUT request to the Zendesk API."""
+        url = f"{self.base_url}/{path}"
+        if self._use_cookies:
+            resp = self._session.put(url, json=data, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        else:
+            body = json.dumps(data).encode()
+            req = urllib.request.Request(url, data=body, method='PUT')
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                return json.loads(response.read().decode())
+
+    def _api_post(self, path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Make a POST request to the Zendesk API."""
+        url = f"{self.base_url}/{path}"
+        if self._use_cookies:
+            resp = self._session.post(url, json=data, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        else:
+            body = json.dumps(data).encode()
+            req = urllib.request.Request(url, data=body, method='POST')
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                return json.loads(response.read().decode())
 
     def get_ticket(self, ticket_id: int) -> Dict[str, Any]:
         """
         Query a ticket by its ID
         """
         try:
-            ticket = self.client.tickets(id=ticket_id)
+            data = self._api_get(f"tickets/{ticket_id}.json")
+            ticket = data['ticket']
             return {
-                'id': ticket.id,
-                'subject': ticket.subject,
-                'description': ticket.description,
-                'status': ticket.status,
-                'priority': ticket.priority,
-                'created_at': str(ticket.created_at),
-                'updated_at': str(ticket.updated_at),
-                'requester_id': ticket.requester_id,
-                'assignee_id': ticket.assignee_id,
-                'organization_id': ticket.organization_id
+                'id': ticket.get('id'),
+                'subject': ticket.get('subject'),
+                'description': ticket.get('description'),
+                'status': ticket.get('status'),
+                'priority': ticket.get('priority'),
+                'created_at': ticket.get('created_at'),
+                'updated_at': ticket.get('updated_at'),
+                'requester_id': ticket.get('requester_id'),
+                'assignee_id': ticket.get('assignee_id'),
+                'organization_id': ticket.get('organization_id')
             }
         except Exception as e:
             raise Exception(f"Failed to get ticket {ticket_id}: {str(e)}")
@@ -57,25 +122,25 @@ class ZendeskClient:
         Get all comments for a specific ticket, including attachment metadata.
         """
         try:
-            comments = self.client.tickets.comments(ticket=ticket_id)
+            data = self._api_get(f"tickets/{ticket_id}/comments.json")
             result = []
-            for comment in comments:
+            for comment in data.get('comments', []):
                 attachments = []
-                for a in getattr(comment, 'attachments', []) or []:
+                for a in comment.get('attachments', []):
                     attachments.append({
-                        'id': a.id,
-                        'file_name': a.file_name,
-                        'content_url': a.content_url,
-                        'content_type': a.content_type,
-                        'size': a.size,
+                        'id': a.get('id'),
+                        'file_name': a.get('file_name'),
+                        'content_url': a.get('content_url'),
+                        'content_type': a.get('content_type'),
+                        'size': a.get('size'),
                     })
                 result.append({
-                    'id': comment.id,
-                    'author_id': comment.author_id,
-                    'body': comment.body,
-                    'html_body': comment.html_body,
-                    'public': comment.public,
-                    'created_at': str(comment.created_at),
+                    'id': comment.get('id'),
+                    'author_id': comment.get('author_id'),
+                    'body': comment.get('body'),
+                    'html_body': comment.get('html_body'),
+                    'public': comment.get('public'),
+                    'created_at': comment.get('created_at', ''),
                     'attachments': attachments,
                 })
             return result
@@ -110,12 +175,19 @@ class ZendeskClient:
         which is required — the CDN returns 403 if it receives an auth header.
         """
         try:
-            response = _requests.get(
-                content_url,
-                headers={'Authorization': self.auth_header},
-                timeout=30,
-                stream=True,
-            )
+            if self._use_cookies:
+                response = self._session.get(
+                    content_url,
+                    timeout=30,
+                    stream=True,
+                )
+            else:
+                response = _requests.get(
+                    content_url,
+                    headers={'Authorization': self.auth_header},
+                    timeout=30,
+                    stream=True,
+                )
             response.raise_for_status()
 
             content_type = response.headers.get('Content-Type', '').split(';')[0].strip().lower()
@@ -163,12 +235,15 @@ class ZendeskClient:
         Post a comment to an existing ticket.
         """
         try:
-            ticket = self.client.tickets(id=ticket_id)
-            ticket.comment = Comment(
-                html_body=comment,
-                public=public
-            )
-            self.client.tickets.update(ticket)
+            data = {
+                "ticket": {
+                    "comment": {
+                        "html_body": comment,
+                        "public": public
+                    }
+                }
+            }
+            self._api_put(f"tickets/{ticket_id}.json", data)
             return comment
         except Exception as e:
             raise Exception(f"Failed to post comment on ticket {ticket_id}: {str(e)}")
@@ -190,25 +265,13 @@ class ZendeskClient:
             # Cap at reasonable limit
             per_page = min(per_page, 100)
 
-            # Build URL with parameters for offset pagination
-            params = {
+            params = urllib.parse.urlencode({
                 'page': str(page),
                 'per_page': str(per_page),
                 'sort_by': sort_by,
                 'sort_order': sort_order
-            }
-            query_string = urllib.parse.urlencode(params)
-            url = f"{self.base_url}/tickets.json?{query_string}"
-
-            # Create request with auth header
-            req = urllib.request.Request(url)
-            req.add_header('Authorization', self.auth_header)
-            req.add_header('Content-Type', 'application/json')
-
-            # Make the API request
-            with urllib.request.urlopen(req) as response:
-                data = json.loads(response.read().decode())
-
+            })
+            data = self._api_get(f"tickets.json?{params}")
             tickets_data = data.get('tickets', [])
 
             # Process tickets to return only essential fields
@@ -237,9 +300,6 @@ class ZendeskClient:
                 'next_page': page + 1 if data.get('next_page') else None,
                 'previous_page': page - 1 if data.get('previous_page') and page > 1 else None
             }
-        except urllib.error.HTTPError as e:
-            error_body = e.read().decode() if e.fp else "No response body"
-            raise Exception(f"Failed to get latest tickets: HTTP {e.code} - {e.reason}. {error_body}")
         except Exception as e:
             raise Exception(f"Failed to get latest tickets: {str(e)}")
 
@@ -249,23 +309,42 @@ class ZendeskClient:
         Returns a Dict of section -> [article].
         """
         try:
-            # Get all sections
-            sections = self.client.help_center.sections()
+            sections_url = f"https://{self.subdomain}.zendesk.com/api/v2/help_center/sections.json"
+            if self._use_cookies:
+                resp = self._session.get(sections_url, timeout=30)
+                resp.raise_for_status()
+                sections_data = resp.json()
+            else:
+                req = urllib.request.Request(sections_url)
+                req.add_header('Authorization', self.auth_header)
+                req.add_header('Content-Type', 'application/json')
+                with urllib.request.urlopen(req) as response:
+                    sections_data = json.loads(response.read().decode())
 
-            # Get articles for each section
             kb = {}
-            for section in sections:
-                articles = self.client.help_center.sections.articles(section.id)
-                kb[section.name] = {
-                    'section_id': section.id,
-                    'description': section.description,
+            for section in sections_data.get('sections', []):
+                articles_url = f"https://{self.subdomain}.zendesk.com/api/v2/help_center/sections/{section['id']}/articles.json"
+                if self._use_cookies:
+                    resp = self._session.get(articles_url, timeout=30)
+                    resp.raise_for_status()
+                    articles_data = resp.json()
+                else:
+                    req = urllib.request.Request(articles_url)
+                    req.add_header('Authorization', self.auth_header)
+                    req.add_header('Content-Type', 'application/json')
+                    with urllib.request.urlopen(req) as response:
+                        articles_data = json.loads(response.read().decode())
+
+                kb[section.get('name', '')] = {
+                    'section_id': section['id'],
+                    'description': section.get('description', ''),
                     'articles': [{
-                        'id': article.id,
-                        'title': article.title,
-                        'body': article.body,
-                        'updated_at': str(article.updated_at),
-                        'url': article.html_url
-                    } for article in articles]
+                        'id': article['id'],
+                        'title': article.get('title', ''),
+                        'body': article.get('body', ''),
+                        'updated_at': article.get('updated_at', ''),
+                        'url': article.get('html_url', '')
+                    } for article in articles_data.get('articles', [])]
                 }
 
             return kb
@@ -284,91 +363,75 @@ class ZendeskClient:
         custom_fields: List[Dict[str, Any]] | None = None,
     ) -> Dict[str, Any]:
         """
-        Create a new Zendesk ticket using Zenpy and return essential fields.
-
-        Args:
-            subject: Ticket subject
-            description: Ticket description (plain text). Will also be used as initial comment.
-            requester_id: Optional requester user ID
-            assignee_id: Optional assignee user ID
-            priority: Optional priority (low, normal, high, urgent)
-            type: Optional ticket type (problem, incident, question, task)
-            tags: Optional list of tags
-            custom_fields: Optional list of dicts: {id: int, value: Any}
+        Create a new Zendesk ticket and return essential fields.
         """
         try:
-            ticket = ZenpyTicket(
-                subject=subject,
-                description=description,
-                requester_id=requester_id,
-                assignee_id=assignee_id,
-                priority=priority,
-                type=type,
-                tags=tags,
-                custom_fields=custom_fields,
-            )
-            created_audit = self.client.tickets.create(ticket)
-            # Fetch created ticket id from audit
-            created_ticket_id = getattr(getattr(created_audit, 'ticket', None), 'id', None)
-            if created_ticket_id is None:
-                # Fallback: try to read id from audit events
-                created_ticket_id = getattr(created_audit, 'id', None)
+            ticket_data: Dict[str, Any] = {
+                "subject": subject,
+                "description": description,
+            }
+            if requester_id is not None:
+                ticket_data["requester_id"] = requester_id
+            if assignee_id is not None:
+                ticket_data["assignee_id"] = assignee_id
+            if priority is not None:
+                ticket_data["priority"] = priority
+            if type is not None:
+                ticket_data["type"] = type
+            if tags is not None:
+                ticket_data["tags"] = tags
+            if custom_fields is not None:
+                ticket_data["custom_fields"] = custom_fields
 
-            # Fetch full ticket to return consistent data
-            created = self.client.tickets(id=created_ticket_id) if created_ticket_id else None
+            result = self._api_post("tickets.json", {"ticket": ticket_data})
+            ticket = result.get('ticket', {})
 
             return {
-                'id': getattr(created, 'id', created_ticket_id),
-                'subject': getattr(created, 'subject', subject),
-                'description': getattr(created, 'description', description),
-                'status': getattr(created, 'status', 'new'),
-                'priority': getattr(created, 'priority', priority),
-                'type': getattr(created, 'type', type),
-                'created_at': str(getattr(created, 'created_at', '')),
-                'updated_at': str(getattr(created, 'updated_at', '')),
-                'requester_id': getattr(created, 'requester_id', requester_id),
-                'assignee_id': getattr(created, 'assignee_id', assignee_id),
-                'organization_id': getattr(created, 'organization_id', None),
-                'tags': list(getattr(created, 'tags', tags or []) or []),
+                'id': ticket.get('id'),
+                'subject': ticket.get('subject', subject),
+                'description': ticket.get('description', description),
+                'status': ticket.get('status', 'new'),
+                'priority': ticket.get('priority', priority),
+                'type': ticket.get('type', type),
+                'created_at': ticket.get('created_at', ''),
+                'updated_at': ticket.get('updated_at', ''),
+                'requester_id': ticket.get('requester_id', requester_id),
+                'assignee_id': ticket.get('assignee_id', assignee_id),
+                'organization_id': ticket.get('organization_id'),
+                'tags': ticket.get('tags', tags or []),
             }
         except Exception as e:
             raise Exception(f"Failed to create ticket: {str(e)}")
 
     def update_ticket(self, ticket_id: int, **fields: Any) -> Dict[str, Any]:
         """
-        Update a Zendesk ticket with provided fields using Zenpy.
+        Update a Zendesk ticket with provided fields.
 
         Supported fields include common ticket attributes like:
         subject, status, priority, type, assignee_id, requester_id,
         tags (list[str]), custom_fields (list[dict]), due_at, etc.
         """
         try:
-            # Load the ticket, mutate fields directly, and update
-            ticket = self.client.tickets(id=ticket_id)
-            for key, value in fields.items():
-                if value is None:
-                    continue
-                setattr(ticket, key, value)
-
-            # This call returns a TicketAudit (not a Ticket). Don't read attrs from it.
-            self.client.tickets.update(ticket)
+            update_data = {k: v for k, v in fields.items() if v is not None}
+            self._api_put(f"tickets/{ticket_id}.json", {"ticket": update_data})
 
             # Fetch the fresh ticket to return consistent data
-            refreshed = self.client.tickets(id=ticket_id)
+            data = self._api_get(f"tickets/{ticket_id}.json")
+            ticket = data['ticket']
 
             return {
-                'id': refreshed.id,
-                'subject': refreshed.subject,
-                'description': refreshed.description,
-                'status': refreshed.status,
-                'priority': refreshed.priority,
-                'type': getattr(refreshed, 'type', None),
-                'created_at': str(refreshed.created_at),
-                'updated_at': str(refreshed.updated_at),
-                'requester_id': refreshed.requester_id,
-                'assignee_id': refreshed.assignee_id,
-                'organization_id': refreshed.organization_id,
-                'tags': list(getattr(refreshed, 'tags', []) or []),
+                'id': ticket.get('id'),
+                'subject': ticket.get('subject'),
+                'description': ticket.get('description'),
+                'status': ticket.get('status'),
+                'priority': ticket.get('priority'),
+                'type': ticket.get('type'),
+                'created_at': ticket.get('created_at', ''),
+                'updated_at': ticket.get('updated_at', ''),
+                'requester_id': ticket.get('requester_id'),
+                'assignee_id': ticket.get('assignee_id'),
+                'organization_id': ticket.get('organization_id'),
+                'tags': ticket.get('tags', []),
             }
         except Exception as e:
             raise Exception(f"Failed to update ticket {ticket_id}: {str(e)}")


### PR DESCRIPTION
## Summary

Adds 17 new MCP tools covering the most valuable Zendesk API endpoints that were missing:

### P0 - Search & Users
- **`search`** - Full-text search using Zendesk Query Language (ZQL)
- **`get_user`** - Resolve user IDs to names/emails
- **`get_current_user`** - Get authenticated user info
- **`search_users`** - Search users by name/email

### P1 - Views, Fields, Orgs, Bulk
- **`list_views`** - List saved ticket queues
- **`execute_view`** - Run a view and get its tickets
- **`list_ticket_fields`** - List all fields with valid options
- **`get_organization`** - Get org details by ID
- **`search_organizations`** - Search orgs by name
- **`get_tickets_bulk`** - Batch fetch up to 100 tickets

### P2 - Groups, Merge, Macros
- **`list_groups`** - List assignable groups
- **`merge_tickets`** - Merge duplicate tickets
- **`list_macros`** - List available macros
- **`apply_macro`** - Preview macro effect on a ticket

### P3 - User Tickets, Forms, Delete
- **`get_user_tickets`** - Tickets by requester/assignee/cc
- **`list_ticket_forms`** - List ticket forms and field mappings
- **`delete_ticket`** - Delete a ticket

Total tools: 7 existing + 17 new = **24 tools**

## Test plan

- [ ] `search` with various ZQL queries
- [ ] `get_user` / `get_current_user` resolve IDs correctly
- [ ] `list_views` + `execute_view` returns ticket queues
- [ ] `list_ticket_fields` shows custom fields with options
- [ ] `get_tickets_bulk` with multiple IDs
- [ ] `list_groups` returns assignable groups
- [ ] `list_macros` + `apply_macro` preview works
- [ ] `delete_ticket` on a test ticket