### PR TITLE
add search_tickets, get_organization, search_users, get_group_users 

### DIFF
--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -254,7 +254,9 @@ async def handle_list_tools() -> list[types.Tool]:
                     "requester_id": {"type": "integer"},
                     "tags": {"type": "array", "items": {"type": "string"}},
                     "custom_fields": {"type": "array", "items": {"type": "object"}},
-                    "due_at": {"type": "string", "description": "ISO8601 datetime"}
+                    "due_at": {"type": "string", "description": "ISO8601 datetime"},
+                    "custom_status_id": {"type": "integer", "description": "Custom ticket status ID (e.g. Feature Request Created, On-Hold/Engineering)"},
+                    "group_id": {"type": "integer", "description": "Zendesk group ID to assign the ticket to"}
                 },
                 "required": ["ticket_id"]
             }

--- a/src/zendesk_mcp_server/server.py
+++ b/src/zendesk_mcp_server/server.py
@@ -240,6 +240,53 @@ async def handle_list_tools() -> list[types.Tool]:
             }
         ),
         types.Tool(
+            name="search_tickets",
+            description="Search Zendesk tickets using a query string (supports assignee, status, priority, org, date filters)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Zendesk search query, e.g. 'type:ticket status:open assignee:me'"},
+                    "sort_by": {"type": "string", "description": "Field to sort by (created_at, updated_at, priority, status)", "default": "created_at"},
+                    "sort_order": {"type": "string", "description": "asc or desc", "default": "asc"},
+                    "per_page": {"type": "integer", "description": "Results per page (max 100)", "default": 10}
+                },
+                "required": ["query"]
+            }
+        ),
+        types.Tool(
+            name="get_organization",
+            description="Retrieve a Zendesk organization by ID, including custom fields",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "organization_id": {"type": "integer", "description": "The ID of the organization to retrieve"}
+                },
+                "required": ["organization_id"]
+            }
+        ),
+        types.Tool(
+            name="search_users",
+            description="Search for Zendesk users by name or email",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Name or email to search for"}
+                },
+                "required": ["query"]
+            }
+        ),
+        types.Tool(
+            name="get_group_users",
+            description="List all users in a Zendesk group",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "group_id": {"type": "integer", "description": "The ID of the group"}
+                },
+                "required": ["group_id"]
+            }
+        ),
+        types.Tool(
             name="update_ticket",
             description="Update fields on an existing Zendesk ticket (e.g., status, priority, assignee_id)",
             inputSchema={
@@ -355,6 +402,35 @@ async def handle_call_tool(
                     type="text",
                     text=json.dumps({"content_type": content_type, "data_base64": result["data"]})
                 )]
+
+        elif name == "search_tickets":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            results = zendesk_client.search_tickets(
+                query=arguments["query"],
+                sort_by=arguments.get("sort_by", "created_at"),
+                sort_order=arguments.get("sort_order", "asc"),
+                per_page=arguments.get("per_page", 10)
+            )
+            return [types.TextContent(type="text", text=json.dumps(results, indent=2))]
+
+        elif name == "get_organization":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            org = zendesk_client.get_organization(arguments["organization_id"])
+            return [types.TextContent(type="text", text=json.dumps(org, indent=2))]
+
+        elif name == "search_users":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            users = zendesk_client.search_users(arguments["query"])
+            return [types.TextContent(type="text", text=json.dumps(users, indent=2))]
+
+        elif name == "get_group_users":
+            if not arguments:
+                raise ValueError("Missing arguments")
+            users = zendesk_client.get_group_users(arguments["group_id"])
+            return [types.TextContent(type="text", text=json.dumps(users, indent=2))]
 
         elif name == "update_ticket":
             if not arguments:

--- a/src/zendesk_mcp_server/zendesk_client.py
+++ b/src/zendesk_mcp_server/zendesk_client.py
@@ -334,6 +334,101 @@ class ZendeskClient:
         except Exception as e:
             raise Exception(f"Failed to create ticket: {str(e)}")
 
+    def search_tickets(self, query: str, sort_by: str = 'created_at', sort_order: str = 'asc', per_page: int = 10) -> Dict[str, Any]:
+        try:
+            per_page = min(per_page, 100)
+            params = {'query': query, 'sort_by': sort_by, 'sort_order': sort_order, 'per_page': str(per_page)}
+            url = f"{self.base_url}/search.json?{urllib.parse.urlencode(params)}"
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+            ticket_list = [
+                {
+                    'id': t.get('id'),
+                    'subject': t.get('subject'),
+                    'status': t.get('status'),
+                    'priority': t.get('priority'),
+                    'created_at': t.get('created_at'),
+                    'updated_at': t.get('updated_at'),
+                    'assignee_id': t.get('assignee_id'),
+                    'organization_id': t.get('organization_id'),
+                }
+                for t in data.get('results', [])
+                if t.get('result_type') == 'ticket'
+            ]
+            return {
+                'tickets': ticket_list,
+                'count': len(ticket_list),
+                'total_count': data.get('count', len(ticket_list)),
+                'has_more': data.get('next_page') is not None,
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to search tickets: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to search tickets: {str(e)}")
+
+    def get_organization(self, organization_id: int) -> Dict[str, Any]:
+        try:
+            url = f"{self.base_url}/organizations/{organization_id}.json"
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+            org = data.get('organization', {})
+            return {
+                'id': org.get('id'),
+                'name': org.get('name'),
+                'organization_fields': org.get('organization_fields', {}),
+                'tags': org.get('tags', []),
+                'created_at': org.get('created_at'),
+                'updated_at': org.get('updated_at'),
+            }
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get organization {organization_id}: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get organization {organization_id}: {str(e)}")
+
+    def search_users(self, query: str) -> List[Dict[str, Any]]:
+        try:
+            url = f"{self.base_url}/users/search.json?{urllib.parse.urlencode({'query': query})}"
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+            return [
+                {'id': u.get('id'), 'name': u.get('name'), 'email': u.get('email'), 'role': u.get('role')}
+                for u in data.get('users', [])
+            ]
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to search users: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to search users: {str(e)}")
+
+    def get_group_users(self, group_id: int) -> List[Dict[str, Any]]:
+        try:
+            url = f"{self.base_url}/groups/{group_id}/users.json"
+            req = urllib.request.Request(url)
+            req.add_header('Authorization', self.auth_header)
+            req.add_header('Content-Type', 'application/json')
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+            return [
+                {'id': u.get('id'), 'name': u.get('name'), 'email': u.get('email')}
+                for u in data.get('users', [])
+            ]
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "No response body"
+            raise Exception(f"Failed to get users for group {group_id}: HTTP {e.code} - {e.reason}. {error_body}")
+        except Exception as e:
+            raise Exception(f"Failed to get users for group {group_id}: {str(e)}")
+
     def update_ticket(self, ticket_id: int, **fields: Any) -> Dict[str, Any]:
         """
         Update a Zendesk ticket with provided fields using Zenpy.


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                         
  - `search_tickets` — search tickets by query string (assignee, status, priority, org, date); replaces curl fallback for filtered searches                                                                          
  - `get_organization` — fetch org by ID including custom fields (e.g. `customer_success_manager`); needed for Feature Request Created flow AM lookup                                                                
  - `search_users` — look up users by name or email; needed to resolve AM name to a Zendesk user ID                                                                                                                  
  - `get_group_users` — list all members of a group; fallback when user search returns no match                                                                                                                      
                                                                                                                                                                                                                     
  All four tools use the same direct urllib.request pattern as get_tickets. Smoke tested against production Zendesk.                                                                                                 
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
  - [x] search_tickets — type:ticket status:open assignee:me returns paginated results                                                                                                                               
  - [x] search_users — email lookup returns correct user ID and role                                                                                                                                                 
  - [x] get_group_users — Account Management group returns full member list                                                                                                                                          
  - [x] get_organization — org lookup returns organization_fields including customer_success_manager